### PR TITLE
BUGFIX: Fix behaviour for fallback dimensions

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,6 @@
+preset: psr2
+
+finder:
+  path:
+    - "Classes"
+    - "Tests"

--- a/Classes/Service/NodeRedirectService.php
+++ b/Classes/Service/NodeRedirectService.php
@@ -23,12 +23,12 @@ use TYPO3\Flow\Mvc\Routing\UriBuilder;
 use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 use TYPO3\Neos\Domain\Model\Domain;
 use TYPO3\Neos\Domain\Service\ContentContext;
-use TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface;
 use TYPO3\Neos\Routing\Exception;
 use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
 use TYPO3\TYPO3CR\Domain\Model\Workspace;
 use TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository;
 use TYPO3\TYPO3CR\Domain\Service\ContentDimensionCombinator;
+use TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface;
 
 /**
  * Service that creates redirects for moved / deleted nodes.
@@ -92,7 +92,7 @@ class NodeRedirectService implements NodeRedirectServiceInterface
      */
     protected $contentDimensionCombinator;
 
-    /*
+    /**
      * @Flow\InjectConfiguration(path="enableRemovedNodeRedirect", package="Neos.RedirectHandler.NeosAdapter")
      * @var array
      */
@@ -134,8 +134,8 @@ class NodeRedirectService implements NodeRedirectServiceInterface
      * @param NodeInterface $node
      * @param Workspace $targetWorkspace
      */
-    protected function createRedirect(NodeInterface $node, Workspace $targetWorkspace) {
-
+    protected function createRedirect(NodeInterface $node, Workspace $targetWorkspace)
+    {
         $context = $this->contextFactory->create([
             'workspaceName' => 'live',
             'invisibleContentShown' => true,

--- a/composer.json
+++ b/composer.json
@@ -4,17 +4,12 @@
     "description": "Neos Redirect Handler",
     "license": "GPL-3.0-or-later",
     "require": {
-        "neos/redirecthandler": "~1.0",
-        "typo3/neos": "~2.2 || dev-master"
+        "neos/redirecthandler": "^1.0",
+        "typo3/neos": "^2.2"
     },
     "autoload": {
         "psr-4": {
             "Neos\\RedirectHandler\\NeosAdapter\\": "Classes"
-        }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.0.x-dev"
         }
     }
 }


### PR DESCRIPTION
Also create redirects for nodes that are not persisted as an independent node within the CR, but used a node within a fallback dimension that "shined" through.
For all independent nodes within other dimensions the "publish" signal is called separately when the user clicks "publish all" and the behavior is already correct.