### PR TITLE
BUGFIX: Fix node URI path comparison

### DIFF
--- a/.travisci.yml
+++ b/.travisci.yml
@@ -1,6 +1,0 @@
-language: php
-php:
-  - '7.0'
-  - '7.1'
-  - '7.2'
-script: composer test

--- a/.travisci.yml
+++ b/.travisci.yml
@@ -1,0 +1,6 @@
+language: php
+php:
+  - '7.0'
+  - '7.1'
+  - '7.2'
+script: composer test

--- a/Tests/Functional/Service/NodeRedirectServiceTest.php
+++ b/Tests/Functional/Service/NodeRedirectServiceTest.php
@@ -140,6 +140,7 @@ class NodeRedirectServiceTest extends FunctionalTestCase
     }
 
     /**
+     * @test
      * @throws \Neos\ContentRepository\Exception\NodeExistsException
      * @throws \Neos\ContentRepository\Exception\NodeTypeNotFoundException
      */
@@ -163,6 +164,7 @@ class NodeRedirectServiceTest extends FunctionalTestCase
     }
 
     /**
+     * @test
      * @throws \Neos\ContentRepository\Exception\NodeExistsException
      * @throws \Neos\ContentRepository\Exception\NodeTypeNotFoundException
      */

--- a/Tests/Functional/Service/NodeRedirectServiceTest.php
+++ b/Tests/Functional/Service/NodeRedirectServiceTest.php
@@ -1,0 +1,225 @@
+<?php
+namespace Neos\RedirectHandler\NeosAdapter\Tests\Functional\Service;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Model\Workspace;
+use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
+use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
+use Neos\ContentRepository\Domain\Service\NodeTypeManager;
+use Neos\Neos\Domain\Model\Site;
+use Neos\Neos\Domain\Repository\SiteRepository;
+use Neos\Neos\Domain\Service\ContentContext;
+use Neos\Neos\Domain\Service\ContentContextFactory;
+use Neos\Neos\Service\PublishingService;
+use Neos\RedirectHandler\NeosAdapter\Service\NodeRedirectService;
+use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\RedirectHandler\Storage\RedirectStorageInterface;
+
+/**
+ * Functional test cases for the NodeRedirectService
+ */
+class NodeRedirectServiceTest extends FunctionalTestCase
+{
+    /**
+     * @var boolean
+     */
+    protected static $testablePersistenceEnabled = true;
+
+    /**
+     * @var NodeRedirectService
+     */
+    protected $nodeRedirectService;
+
+    /**
+     * @var WorkspaceRepository
+     */
+    protected $workspaceRepository;
+
+    /**
+     * @var RedirectStorageInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $mockRedirectStorage;
+
+    /**
+     * @var ContentContextFactory
+     */
+    protected $contentContextFactory;
+
+    /**
+     * @var NodeDataRepository
+     */
+    protected $nodeDataRepository;
+
+    /**
+     * @var NodeTypeManager
+     */
+    protected $nodeTypeManager;
+
+    /**
+     * @var Workspace
+     */
+    protected $liveWorkspace;
+
+    /**
+     * @var Workspace
+     */
+    protected $userWorkspace;
+
+    /**
+     * @var ContentContext
+     */
+    protected $userContext;
+
+    /**
+     * @var NodeInterface
+     */
+    protected $site;
+
+    /**
+     * @var PublishingService
+     */
+    protected $publishingService;
+
+    /**
+     * @var SiteRepository
+     */
+    protected $siteRepository;
+
+    /**
+     * @throws \Neos\Flow\Persistence\Exception\IllegalObjectTypeException
+     * @throws \Neos\ContentRepository\Exception\NodeExistsException
+     * @throws \Neos\ContentRepository\Exception\NodeTypeNotFoundException
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->nodeRedirectService = $this->objectManager->get(NodeRedirectService::class);
+        $this->publishingService = $this->objectManager->get(PublishingService::class);
+        $this->nodeDataRepository = $this->objectManager->get(NodeDataRepository::class);
+        $this->siteRepository = $this->objectManager->get(SiteRepository::class);
+        $this->mockRedirectStorage = $this->getMockBuilder(RedirectStorageInterface::class)->getMock();
+        $this->inject($this->nodeRedirectService, 'redirectStorage', $this->mockRedirectStorage);
+        $this->contentContextFactory = $this->objectManager->get(ContentContextFactory::class);
+        $this->nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);
+        $this->workspaceRepository = $this->objectManager->get(WorkspaceRepository::class);
+        $this->liveWorkspace = new Workspace('live');
+        $this->userWorkspace = new Workspace('user-me', $this->liveWorkspace);
+        $this->workspaceRepository->add($this->liveWorkspace);
+        $this->workspaceRepository->add($this->userWorkspace);
+        $liveContext = $this->contentContextFactory->create([
+            'workspaceName' => 'live'
+        ]);
+        $this->userContext = $this->contentContextFactory->create([
+            'workspaceName' => 'user-me'
+        ]);
+
+        $sites = $liveContext->getRootNode()->createNode('sites');
+        $this->site = $sites->createNode('site', $this->nodeTypeManager->getNodeType('Neos.Neos:Document'), 'site');
+        $site = new Site('site');
+        $site->setSiteResourcesPackageKey('My.Package');
+        $this->siteRepository->add($site);
+    }
+
+    /**
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        $this->inject($this->contentContextFactory, 'contextInstances', array());
+    }
+
+    /**
+     * @throws \Neos\ContentRepository\Exception\NodeExistsException
+     * @throws \Neos\ContentRepository\Exception\NodeTypeNotFoundException
+     */
+    public function createRedirectsForPublishedNodeCreatesRedirectFromPreviousUriWhenMovingDocumentDown()
+    {
+        $documentNodeType = $this->nodeTypeManager->getNodeType('Neos.Neos:Document');
+
+        $this->mockRedirectStorage->expects($this->exactly(1))
+            ->method('addRedirect')
+            ->with('/en/document.html', '/en/outer/document.html');
+
+        $outerDocument = $this->site->createNode('outer', $documentNodeType);
+        $outerDocument->setProperty('uriPathSegment', 'outer');
+        $document = $this->site->createNode('document', $documentNodeType, 'document');
+        $document->setProperty('uriPathSegment', 'document');
+
+        $documentToBeMoved = $this->userContext->adoptNode($document);
+        $documentToBeMoved->moveInto($outerDocument);
+
+        $this->publishingService->publishNode($documentToBeMoved);
+    }
+
+    /**
+     * @throws \Neos\ContentRepository\Exception\NodeExistsException
+     * @throws \Neos\ContentRepository\Exception\NodeTypeNotFoundException
+     */
+    public function createRedirectsForPublishedNodeCreatesRedirectFromPreviousUriWhenMovingDocumentUp()
+    {
+        $documentNodeType = $this->nodeTypeManager->getNodeType('Neos.Neos:Document');
+
+        $this->mockRedirectStorage->expects($this->exactly(1))
+            ->method('addRedirect')
+            ->with('/en/outer/document.html', '/en/document.html');
+
+        $outerDocument = $this->site->createNode('outer', $documentNodeType);
+        $outerDocument->setProperty('uriPathSegment', 'outer');
+        $document = $outerDocument->createNode('document', $documentNodeType, 'document');
+        $document->setProperty('uriPathSegment', 'document');
+
+        $documentToBeMoved = $this->userContext->adoptNode($document);
+        $documentToBeMoved->moveInto($this->site);
+
+        $this->publishingService->publishNode($documentToBeMoved);
+    }
+
+    /**
+     * @test
+     * @throws \Neos\ContentRepository\Exception\NodeExistsException
+     * @throws \Neos\ContentRepository\Exception\NodeTypeNotFoundException
+     */
+    public function createRedirectsForPublishedNodeLeavesUpwardRedirectWhenMovingDocumentDownAndUp()
+    {
+        $documentNodeType = $this->nodeTypeManager->getNodeType('Neos.Neos:Document');
+
+        $this->mockRedirectStorage->expects($this->exactly(2))
+            ->method('addRedirect')
+            ->with($this->logicalOr(
+                    $this->equalTo('/en/document.html'),
+                    $this->equalTo('/en/outer/document.html')
+                ),
+                $this->logicalOr(
+                    $this->equalTo('/en/outer/document.html'),
+                    $this->equalTo('/en/document.html')
+                )
+            );
+
+        $outerDocument = $this->site->createNode('outer', $documentNodeType, 'outer');
+        $outerDocument->setProperty('uriPathSegment', 'outer');
+        $document = $this->site->createNode('document', $documentNodeType, 'document');
+        $document->setProperty('uriPathSegment', 'document');
+
+        $documentToBeMoved = $this->userContext->adoptNode($document);
+        $documentToBeMoved->moveInto($this->userContext->getNodeByIdentifier('outer'));
+        $this->publishingService->publishNode($documentToBeMoved);
+        $this->nodeDataRepository->persistEntities();
+
+        $documentToBeMoved = $this->userContext->adoptNode($outerDocument->getNode('document'));
+        $documentToBeMoved->moveInto($this->userContext->getNodeByIdentifier('site'));
+
+        $this->publishingService->publishNode($documentToBeMoved);
+        $this->nodeDataRepository->persistEntities();
+    }
+}


### PR DESCRIPTION
This prevents the same node in contexts differing only in visibility
properties from having different paths during comparison.

The previous behavior led to erratic redirects being created when moving a document deeper into the tree, then back to its original position and so on