### PR TITLE
WIP: BUGFIX: Create a 410-Gone redirect for deleted nodes

### DIFF
--- a/Tests/Behavior/Features/Bootstrap/RedirectOperationTrait.php
+++ b/Tests/Behavior/Features/Bootstrap/RedirectOperationTrait.php
@@ -20,6 +20,17 @@ use PHPUnit\Framework\Assert;
 trait RedirectOperationTrait
 {
     /**
+     * @Given /^I have no redirects$/
+     */
+    public function iHaveNoRedirects()
+    {
+        $nodeRedirectStorage = $this->objectManager->get(RedirectStorage::class);
+        $redirectRepository = $this->objectManager->get(RedirectRepository::class);
+        $nodeRedirectStorage->removeAll();
+        $redirectRepository->persistEntities();
+    }
+
+    /**
      * @Given /^I have the following redirects:$/
      * @When /^I create the following redirects:$/
      */

--- a/Tests/Behavior/Features/Bootstrap/RedirectOperationTrait.php
+++ b/Tests/Behavior/Features/Bootstrap/RedirectOperationTrait.php
@@ -32,7 +32,8 @@ trait RedirectOperationTrait
         foreach ($rows as $row) {
             $nodeRedirectStorage->addRedirect(
                 $this->buildActualUriPath($row['sourceuripath']),
-                $this->buildActualUriPath($row['targeturipath'])
+                $this->buildActualUriPath($row['targeturipath']),
+                isset($row['statuscode']) ? (int)$row['statuscode'] : 307
             );
         }
 
@@ -67,6 +68,25 @@ trait RedirectOperationTrait
         if ($redirect !== null) {
             Assert::assertEquals($targetUri, $redirect->getTargetUriPath(),
                 'A redirect was created, but the target URI does not match'
+            );
+        } else {
+            Assert::assertNotNull($redirect, 'No redirect was created for asserted sourceUri');
+        }
+    }
+
+    /**
+     *  @Given /^I should have a redirect with sourceUri "([^"]*)" and statusCode "([^"]*)"$/
+     */
+    public function iShouldHaveARedirectWithSourceUriAndStatusCode($sourceUri, $statusCode)
+    {
+        $nodeRedirectStorage = $this->objectManager->get(RedirectStorage::class);
+        $sourceUri = $this->buildActualUriPath($sourceUri);
+
+        $redirect = $nodeRedirectStorage->getOneBySourceUriPathAndHost($sourceUri);
+
+        if ($redirect !== null) {
+            Assert::assertEquals((string)$statusCode, (string)$redirect->getStatusCode(),
+                'A redirect was created, but the statusCode does not match'
             );
         } else {
             Assert::assertNotNull($redirect, 'No redirect was created for asserted sourceUri');

--- a/Tests/Behavior/Features/Redirect.feature
+++ b/Tests/Behavior/Features/Redirect.feature
@@ -127,3 +127,12 @@ Feature: Redirects are created automatically when the URI of an existing node is
     And I publish the node
     Then I should have a redirect with sourceUri "en/company.html" and targetUri "en/service/company.html"
     And I should have a redirect with sourceUri "de/company.html" and targetUri "de/service/company.html"
+
+  @fixtures
+  Scenario: Deleted nodes create a redirect with 410 Status
+    When I get a node by path "/sites/behat/about" with the following context:
+        | Workspace        |
+        | user-testaccount |
+    And I remove the node
+    And I publish the workspace "user-testaccount"
+    And I should have a redirect with sourceUri "en/about.html" and statusCode "410"

--- a/Tests/Behavior/Features/Redirect.feature
+++ b/Tests/Behavior/Features/Redirect.feature
@@ -19,6 +19,7 @@ Feature: Redirects are created automatically when the URI of an existing node is
       | 4bba27c8-5029-4ae6-8371-0f2b3e1700a9 | /sites/behat/buy       | Neos.Neos:Document         | {"uriPathSegment": "kaufen"}              | live      | true   | de            |
       | 81dc6c8c-f478-434c-9ac9-bd5d1781cd95 | /sites/behat/mail      | Neos.Neos:Document         | {"uriPathSegment": "mail"}                | live      |        | en            |
       | 81dc6c8c-f478-434c-9ac9-bd5d1781cd95 | /sites/behat/mail      | Neos.Neos:Document         | {"uriPathSegment": "mail"}                | live      | true   | de            |
+    And I have no redirects
 
   @fixtures
   Scenario: Move a node into different node and a redirect will be created
@@ -131,8 +132,18 @@ Feature: Redirects are created automatically when the URI of an existing node is
   @fixtures
   Scenario: Deleted nodes create a redirect with 410 Status
     When I get a node by path "/sites/behat/about" with the following context:
-        | Workspace        |
-        | user-testaccount |
+      | Workspace        |
+      | user-testaccount |
     And I remove the node
     And I publish the workspace "user-testaccount"
-    And I should have a redirect with sourceUri "en/about.html" and statusCode "410"
+    Then I should have a redirect with sourceUri "en/about.html" and statusCode "410"
+
+  @fixtures
+  Scenario: Hidden nodes create no redirect
+    When I get a node by path "/sites/behat/about" with the following context:
+      | Workspace        |
+      | user-testaccount |
+    And I hide the node
+    And I publish the workspace "user-testaccount"
+    Then I should have no redirect with sourceUri "en/about.html"
+


### PR DESCRIPTION
If a node cannot be read in the createPendingRedirects stage it is considered to have been deleted and the removeNodeRedirect method is triggered.

I addition the restrictions are applied in the collect stage to work on removed nodes but 
also to work on the origin before the publishing as specified in the docs.

fixes: #31 