### PR TITLE
FEATURE: Completely disable automatic generation

### DIFF
--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -15,10 +15,10 @@ namespace Neos\RedirectHandler\NeosAdapter;
 
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\RedirectHandler\NeosAdapter\Service\NodeRedirectService;
+use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Package\Package as BasePackage;
 use Neos\ContentRepository\Domain\Model\Workspace;
-use Neos\Flow\Annotations as Flow;
 
 /**
  * The Neos RedirectHandler NeosAdapter Package
@@ -26,18 +26,15 @@ use Neos\Flow\Annotations as Flow;
 class Package extends BasePackage
 {
     /**
-     * @Flow\InjectConfiguration(path="disableAutomaticRedirects")
-     * @var boolean
-     */
-    protected $disableAutomaticRedirects;
-
-    /**
      * @param Bootstrap $bootstrap The current bootstrap
      * @return void
      */
     public function boot(Bootstrap $bootstrap): void
     {
-        if ($this->disableAutomaticRedirects === false) {
+        $configurationManager = $bootstrap->getObjectManager()->get(ConfigurationManager::class);
+        $settings = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, $this->getPackageKey());
+
+        if (isset($settings['enableAutomaticRedirects']) && $settings['enableAutomaticRedirects'] === true) {
             $dispatcher = $bootstrap->getSignalSlotDispatcher();
 
             $dispatcher->connect(Workspace::class, 'beforeNodePublishing', NodeRedirectService::class, 'collectPossibleRedirects');

--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -18,6 +18,7 @@ use Neos\RedirectHandler\NeosAdapter\Service\NodeRedirectService;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Package\Package as BasePackage;
 use Neos\ContentRepository\Domain\Model\Workspace;
+use Neos\Flow\Annotations as Flow;
 
 /**
  * The Neos RedirectHandler NeosAdapter Package
@@ -25,14 +26,22 @@ use Neos\ContentRepository\Domain\Model\Workspace;
 class Package extends BasePackage
 {
     /**
+     * @Flow\InjectConfiguration(path="disableAutomaticRedirects")
+     * @var boolean
+     */
+    protected $disableAutomaticRedirects;
+
+    /**
      * @param Bootstrap $bootstrap The current bootstrap
      * @return void
      */
     public function boot(Bootstrap $bootstrap): void
     {
-        $dispatcher = $bootstrap->getSignalSlotDispatcher();
+        if ($this->disableAutomaticRedirects === false) {
+            $dispatcher = $bootstrap->getSignalSlotDispatcher();
 
-        $dispatcher->connect(Workspace::class, 'beforeNodePublishing', NodeRedirectService::class, 'collectPossibleRedirects');
-        $dispatcher->connect(PersistenceManager::class, 'allObjectsPersisted', NodeRedirectService::class, 'createPendingRedirects');
+            $dispatcher->connect(Workspace::class, 'beforeNodePublishing', NodeRedirectService::class, 'collectPossibleRedirects');
+            $dispatcher->connect(PersistenceManager::class, 'allObjectsPersisted', NodeRedirectService::class, 'createPendingRedirects');
+        }
     }
 }

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -17,4 +17,4 @@ Neos:
 
       # in some cases you might need to completely disable the automatic redirects
       # e.g. on cli, during imports or similar
-      disableAutomaticRedirects: false
+      enableAutomaticRedirects: true

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -14,3 +14,7 @@ Neos:
 
       restrictByOldUriPrefix: []
       #  '/some/uri/path/': true
+
+      # in some cases you might need to completely disable the automatic redirects
+      # e.g. on cli, during imports or similar
+      disableAutomaticRedirects: false

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -75,6 +75,19 @@ Restrict redirect generation by old URI prefix.
   restrictByOldUriPrefix:
     '/some/uri/path': true
 
+enableAutomaticRedirects
+^^^^^^^^^^^^^^^^^^^^^^
+
+Completely disable redirect generation.
+
+**Note**: There might be edge cases where you need to disable redirect generation completely
+(comes in handy when using a dedicated subcontext).
+Redirect generation can slow down large node operations, imports etc.
+
+.. code-block:: yaml
+
+  enableAutomaticRedirects: false
+
 ===============================
 Exporting & importing redirects
 ===============================


### PR DESCRIPTION
This is helpful for any cli actions, large imports etc.
On cli you can get exceptions due to missing HttpRequest.
And in large import scenarios the Slot for allObjectsPersisted signal
can slow down the import process.

Explicitly disabling automatic redirects deems more intuitive than
implicitly enabling it - you have to know what you are doing.
This is why we put in a disable* setting instead of an enable* setting