### PR TITLE
BUGFIX: Adjust settings to renamed config

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -9,8 +9,8 @@ Neos:
       pathPrefixConfiguration: []
       #  '/sites/neosdemo/': false
 
-      nodeTypeConfiguration:
-        Neos.Neos:Document: true
+      restrictByNodeType: []
+      #  Neos.Neos:Document: true
 
       restrictByOldUriPrefix: []
       #  '/some/uri/path/': true


### PR DESCRIPTION
The configuration key was renamed in https://github.com/neos/redirecthandler-neosadapter/commit/59ba3e4606c76c3d150c076091c09636c0d5a41f

Resolves: #43 