### PR TITLE
BUGFIX: Prevent error on publish workspace via cli

### DIFF
--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -32,7 +32,9 @@ class Package extends BasePackage
     {
         $dispatcher = $bootstrap->getSignalSlotDispatcher();
 
-        $dispatcher->connect(Workspace::class, 'beforeNodePublishing', NodeRedirectService::class, 'collectPossibleRedirects');
-        $dispatcher->connect(PersistenceManager::class, 'allObjectsPersisted', NodeRedirectService::class, 'createPendingRedirects');
+        if (FLOW_SAPITYPE !== 'CLI') {
+            $dispatcher->connect(Workspace::class, 'beforeNodePublishing', NodeRedirectService::class, 'collectPossibleRedirects');
+            $dispatcher->connect(PersistenceManager::class, 'allObjectsPersisted', NodeRedirectService::class, 'createPendingRedirects');
+        }
     }
 }

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -75,6 +75,14 @@ Restrict redirect generation by old URI prefix.
   restrictByOldUriPrefix:
     '/some/uri/path': true
 
+limitations
+^^^^^^^^^^^
+
+When publishing workspaces via the cli the automatic redirect generation is disabled
+as the uris cannot be reliably generated in the cli context.
+
+It's planned to fix this in a future release.
+
 ===============================
 Exporting & importing redirects
 ===============================


### PR DESCRIPTION
When publishing a workspace via the cli
the redirect package is triggered to
create new redirects if necessary when nodes
have been moved. This causes errors and
prevents the publish because the baseuris
cannot be generated.

This is a hotfix and can be replaced by a
actual working redirect generation in the future.

Relates: #41