### PR TITLE
FEATURE: Allow automatic redirect generation for CLI publishing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,9 +39,8 @@ jobs:
       run: |
         git clone https://github.com/neos/flow-base-distribution.git -b ${FLOW_TARGET_VERSION} ${FLOW_FOLDER}
         cd ${FLOW_FOLDER}
-        composer require --no-update --no-interaction neos/redirecthandler:4.0.x-dev
-        composer require --no-update --no-interaction neos/redirecthandler-databasestorage:4.0.x-dev
-        composer require --no-update --no-interaction neos/redirecthandler-neosadapter:dev-master
+        composer require --no-update --no-interaction neos/redirecthandler-databasestorage:~4.0
+        composer require --no-update --no-interaction neos/redirecthandler-neosadapter:~4.0
 
     - name: Install distribution
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         cd ${FLOW_FOLDER}
         composer install --no-interaction --no-progress
-        rm -rf Packages/Application/Neos.RedirectHandler.DatabaseStorage
+        rm -rf Packages/Application/Neos.RedirectHandler.NeosAdapter
         cp -r ../redirecthandler-neosadapter Packages/Application/Neos.RedirectHandler.NeosAdapter
 
     - name: Run Functional tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,56 @@
+name: Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    env:
+      FLOW_TARGET_VERSION: 6.3
+      FLOW_CONTEXT: Testing
+      FLOW_FOLDER: ../flow-base-distribution
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Update Composer
+      run: |
+        sudo composer self-update
+        composer --version
+
+    # Directory permissions for .composer are wrong, so we remove the complete directory
+    # https://github.com/actions/virtual-environments/issues/824
+    - name: Delete .composer directory
+      run: |
+        sudo rm -rf ~/.composer
+
+    - name: Cache dependencies
+      uses: actions/cache@v1
+      with:
+        path: ~/.composer/cache
+        key: dependencies-composer-${{ hashFiles('composer.json') }}
+
+    - name: Prepare Flow distribution
+      run: |
+        git clone https://github.com/neos/flow-base-distribution.git -b ${FLOW_TARGET_VERSION} ${FLOW_FOLDER}
+        cd ${FLOW_FOLDER}
+        composer require --no-update --no-interaction neos/redirecthandler:4.0.x-dev
+        composer require --no-update --no-interaction neos/redirecthandler-databasestorage:4.0.x-dev
+        composer require --no-update --no-interaction neos/redirecthandler-neosadapter:dev-master
+
+    - name: Install distribution
+      run: |
+        cd ${FLOW_FOLDER}
+        composer install --no-interaction --no-progress
+        rm -rf Packages/Application/Neos.RedirectHandler.DatabaseStorage
+        cp -r ../redirecthandler-neosadapter Packages/Application/Neos.RedirectHandler.NeosAdapter
+
+    - name: Run Functional tests
+      run: |
+        cd ${FLOW_FOLDER}
+        bin/phpunit --colors -c Build/BuildEssentials/PhpUnit/FunctionalTests.xml Packages/Application/Neos.RedirectHandler.NeosAdapter/Tests/Functional/*

--- a/Classes/Service/NodeRedirectService.php
+++ b/Classes/Service/NodeRedirectService.php
@@ -24,7 +24,9 @@ use Neos\Flow\Cli\CommandRequestHandler;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Http\Exception as HttpException;
 use Neos\Flow\Http\HttpRequestHandlerInterface;
+use Neos\Flow\Http\ServerRequestAttributes;
 use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\Mvc\Routing\Dto\RouteParameters;
 use Neos\Flow\Mvc\Routing\Exception\MissingActionNameException;
 use Neos\Flow\Mvc\Routing\RouterCachingService;
 use Neos\Flow\Mvc\Routing\UriBuilder;
@@ -200,6 +202,8 @@ class NodeRedirectService
         }
 
         if (method_exists(ActionRequest::class, 'fromHttpRequest')) {
+            $routeParameters = $httpRequest->getAttribute(ServerRequestAttributes::ROUTING_PARAMETERS) ?? RouteParameters::createEmpty();
+            $httpRequest = $httpRequest->withAttribute(ServerRequestAttributes::ROUTING_PARAMETERS, $routeParameters->withParameter('requestUriHost', $httpRequest->getUri()->getHost()));
             // From Flow 6+ we have to use a static method to create an ActionRequest. Earlier versions use the constructor.
             $this->actionRequestForUriBuilder = ActionRequest::fromHttpRequest($httpRequest);
         } else {

--- a/Classes/Service/NodeRedirectService.php
+++ b/Classes/Service/NodeRedirectService.php
@@ -234,6 +234,7 @@ class NodeRedirectService
             [$nodeIdentifier, $workspaceName] = explode('@', $nodeIdentifierAndWorkspace);
             $this->buildRedirects($nodeIdentifier, $workspaceName, $oldUriPerDimensionCombination);
         }
+        $this->pendingRedirects = [];
 
         $this->persistenceManager->persistAll();
     }

--- a/Classes/Service/NodeRedirectService.php
+++ b/Classes/Service/NodeRedirectService.php
@@ -202,8 +202,8 @@ class NodeRedirectService
         }
 
         if (method_exists(ActionRequest::class, 'fromHttpRequest')) {
-            $routeParameters = $httpRequest->getAttribute(ServerRequestAttributes::ROUTING_PARAMETERS) ?? RouteParameters::createEmpty();
-            $httpRequest = $httpRequest->withAttribute(ServerRequestAttributes::ROUTING_PARAMETERS, $routeParameters->withParameter('requestUriHost', $httpRequest->getUri()->getHost()));
+            $routeParameters = $httpRequest->getAttribute('routingParameters') ?? RouteParameters::createEmpty();
+            $httpRequest = $httpRequest->withAttribute('routingParameters', $routeParameters->withParameter('requestUriHost', $httpRequest->getUri()->getHost()));
             // From Flow 6+ we have to use a static method to create an ActionRequest. Earlier versions use the constructor.
             $this->actionRequestForUriBuilder = ActionRequest::fromHttpRequest($httpRequest);
         } else {

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -18,3 +18,9 @@ Neos:
       # in some cases you might need to completely disable the automatic redirects
       # e.g. on cli, during imports or similar
       enableAutomaticRedirects: true
+
+      # In cases like publishing changes from the CLI a baseUri is needed to build
+      # a custom request to generate correct redirect uris.
+      # This uri will not be used during publishing from the Neos backend.
+      # If not set, `Neos.Flow.http.baseUri` is used
+      baseUriForAutomaticRedirects: '%env:NEOS_REDIRECTHANDLER_BASEURI%'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -18,9 +18,3 @@ Neos:
       # in some cases you might need to completely disable the automatic redirects
       # e.g. on cli, during imports or similar
       enableAutomaticRedirects: true
-
-      # In cases like publishing changes from the CLI a baseUri is needed to build
-      # a custom request to generate correct redirect uris.
-      # This uri will not be used during publishing from the Neos backend.
-      # If not set, `Neos.Flow.http.baseUri` is used
-      baseUriForAutomaticRedirects: '%env:NEOS_REDIRECTHANDLER_BASEURI%'

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -152,3 +152,18 @@ If you have the `Neos.RedirectHandler.Ui` [package](https://github.com/neos/redi
 you can also export the redirects via the UI in the redirect handler backend module.
 
 The same restrictions and requirements apply as for the import via the CLI.
+
+
+===========================================
+Redirect generation when publishing via CLI
+===========================================
+
+When publishing nodes from CLI f.e. via `flow workspace:publish` you might need additional configuration
+to make sure that redirects are properly generated.
+As commands don't have a http request, a fake http request has to be generated to make the url generation work.
+In this case the setting `Neos.Flow.http.baseUri` will be used.
+If this is not set `http://localhost` is used.
+
+This should not be a problem in most cases as without an active domain for a site
+only relative redirects are generated.
+If a site has an active domain this on will be used to set the `Origin domain` for a new redirect.

--- a/Tests/Behavior/Features/Bootstrap/FeatureContext.php
+++ b/Tests/Behavior/Features/Bootstrap/FeatureContext.php
@@ -1,17 +1,18 @@
 <?php
 
-require_once(__DIR__ . '/../../../../../Neos.Behat/Tests/Behat/FlowContext.php');
+require_once(__DIR__ . '/../../../../../Neos.Behat/Tests/Behat/FlowContextTrait.php');
 require_once(__DIR__ . '/../../../../../../Neos/Neos.ContentRepository/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php');
 require_once(__DIR__ . '/RedirectOperationTrait.php');
 require_once(__DIR__ . '/../../../../../../Neos/Neos.ContentRepository/Tests/Behavior/Features/Bootstrap/NodeAuthorizationTrait.php');
 require_once(__DIR__ . '/../../../../../../Framework/Neos.Flow/Tests/Behavior/Features/Bootstrap/IsolatedBehatStepsTrait.php');
 require_once(__DIR__ . '/../../../../../../Framework/Neos.Flow/Tests/Behavior/Features/Bootstrap/SecurityOperationsTrait.php');
 
+use Behat\MinkExtension\Context\MinkContext;
+use Neos\Behat\Tests\Behat\FlowContextTrait;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\ContentRepository\Service\AuthorizationService;
 use Neos\ContentRepository\Tests\Behavior\Features\Bootstrap\NodeAuthorizationTrait;
 use Neos\ContentRepository\Tests\Behavior\Features\Bootstrap\NodeOperationsTrait;
-use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Tests\Behavior\Features\Bootstrap\IsolatedBehatStepsTrait;
 use Neos\Flow\Tests\Behavior\Features\Bootstrap\SecurityOperationsTrait;
 use Neos\RedirectHandler\NeosAdapter\Tests\Behavior\Features\Bootstrap\RedirectOperationTrait;
@@ -19,27 +20,24 @@ use Neos\RedirectHandler\NeosAdapter\Tests\Behavior\Features\Bootstrap\RedirectO
 /**
  * Features context
  */
-class FeatureContext extends \Neos\Behat\Tests\Behat\FlowContext
+class FeatureContext extends MinkContext
 {
-    use NodeOperationsTrait;
+    use FlowContextTrait;
     use NodeAuthorizationTrait;
     use IsolatedBehatStepsTrait;
     use SecurityOperationsTrait;
     use RedirectOperationTrait;
-
-    /**
-     * @var ObjectManagerInterface
-     */
-    protected $objectManager;
+    use NodeOperationsTrait;
 
     /**
      * Initializes the context
-     *
-     * @param array $parameters Context parameters (configured through behat.yml)
      */
-    public function __construct(array $parameters)
+    public function __construct()
     {
-        parent::__construct($parameters);
+        if (self::$bootstrap === null) {
+            self::$bootstrap = $this->initializeFlow();
+        }
+        $this->objectManager = self::$bootstrap->getObjectManager();
         $this->nodeAuthorizationService = $this->objectManager->get(AuthorizationService::class);
         $this->nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);
         $this->setupSecurity();

--- a/Tests/Behavior/Features/Bootstrap/RedirectOperationTrait.php
+++ b/Tests/Behavior/Features/Bootstrap/RedirectOperationTrait.php
@@ -11,7 +11,6 @@ namespace Neos\RedirectHandler\NeosAdapter\Tests\Behavior\Features\Bootstrap;
  * source code.
  */
 
-use Neos\Flow\Http\Request;
 use Neos\RedirectHandler\DatabaseStorage\Domain\Repository\RedirectRepository;
 use Neos\RedirectHandler\NeosAdapter\Service\NodeRedirectService;
 use Neos\RedirectHandler\DatabaseStorage\RedirectStorage;
@@ -23,7 +22,7 @@ trait RedirectOperationTrait
      * @Given /^I have the following redirects:$/
      * @When /^I create the following redirects:$/
      */
-    public function iHaveTheFollowingRedirects($table)
+    public function iHaveTheFollowingRedirects($table): void
     {
         $rows = $table->getHash();
         $nodeRedirectStorage = $this->objectManager->get(RedirectStorage::class);
@@ -31,8 +30,8 @@ trait RedirectOperationTrait
 
         foreach ($rows as $row) {
             $nodeRedirectStorage->addRedirect(
-                $this->buildActualUriPath($row['sourceuripath']),
-                $this->buildActualUriPath($row['targeturipath'])
+                $row['sourceuripath'],
+                $row['targeturipath']
             );
         }
 
@@ -42,7 +41,7 @@ trait RedirectOperationTrait
     /**
      * @Then /^A redirect should be created for the node with path "([^"]*)" and with the following context:$/
      */
-    public function aRedirectShouldBeCreatedForTheNodeWithPathAndWithTheFollowingContext($path, $table)
+    public function aRedirectShouldBeCreatedForTheNodeWithPathAndWithTheFollowingContext($path, $table): void
     {
         $rows = $table->getHash();
         $context = $this->getContextForProperties($rows[0]);
@@ -56,16 +55,16 @@ trait RedirectOperationTrait
     /**
      *  @Given /^I should have a redirect with sourceUri "([^"]*)" and targetUri "([^"]*)"$/
      */
-    public function iShouldHaveARedirectWithSourceUriAndTargetUri($sourceUri, $targetUri)
+    public function iShouldHaveARedirectWithSourceUriAndTargetUri($sourceUri, $targetUri): void
     {
         $nodeRedirectStorage = $this->objectManager->get(RedirectStorage::class);
-        $targetUri = $this->buildActualUriPath($targetUri);
-        $sourceUri = $this->buildActualUriPath($sourceUri);
 
         $redirect = $nodeRedirectStorage->getOneBySourceUriPathAndHost($sourceUri);
 
         if ($redirect !== null) {
-            Assert::assertEquals($targetUri, $redirect->getTargetUriPath(),
+            Assert::assertEquals(
+                $targetUri,
+                $redirect->getTargetUriPath(),
                 'A redirect was created, but the target URI does not match'
             );
         } else {
@@ -76,16 +75,15 @@ trait RedirectOperationTrait
     /**
      *  @Given /^I should have no redirect with sourceUri "([^"]*)" and targetUri "([^"]*)"$/
      */
-    public function iShouldHaveNoRedirectWithSourceUriAndTargetUri($sourceUri, $targetUri)
+    public function iShouldHaveNoRedirectWithSourceUriAndTargetUri($sourceUri, $targetUri): void
     {
         $nodeRedirectStorage = $this->objectManager->get(RedirectStorage::class);
-        $targetUri = $this->buildActualUriPath($targetUri);
-        $sourceUri = $this->buildActualUriPath($sourceUri);
-
         $redirect = $nodeRedirectStorage->getOneBySourceUriPathAndHost($sourceUri);
 
         if ($redirect !== null) {
-            Assert::assertNotEquals($targetUri, $redirect->getTargetUriPath(),
+            Assert::assertNotEquals(
+                $targetUri,
+                $redirect->getTargetUriPath(),
                 'An untwanted redirect was created for given source and target URI'
             );
         }
@@ -96,27 +94,12 @@ trait RedirectOperationTrait
     /**
      *  @Given /^I should have no redirect with sourceUri "([^"]*)"$/
      */
-    public function iShouldHaveNoRedirectWithSourceUri($sourceUri)
+    public function iShouldHaveNoRedirectWithSourceUri($sourceUri): void
     {
         $nodeRedirectStorage = $this->objectManager->get(RedirectStorage::class);
-        $sourceUri = $this->buildActualUriPath($sourceUri);
 
         $redirect = $nodeRedirectStorage->getOneBySourceUriPathAndHost($sourceUri);
 
         Assert::assertNull($redirect);
-    }
-
-    /**
-     * Return the actual URI path since the request comes from CLI.
-     *
-     * @param $uri
-     *
-     * @return string
-     */
-    protected function buildActualUriPath($uri)
-    {
-        $httpRequest = Request::createFromEnvironment();
-
-        return ltrim($httpRequest->getBaseUri()->getPath() . 'index.php/' . $uri, '/');
     }
 }

--- a/Tests/Behavior/behat.yml
+++ b/Tests/Behavior/behat.yml
@@ -1,0 +1,25 @@
+# Behat distribution configuration
+#
+# Override with behat.yml for local configuration.
+#
+default:
+  autoload:
+    '': "%paths.base%/Features/Bootstrap"
+  suites:
+    content:
+        paths:
+          - "%paths.base%/Features"
+        contexts:
+          - FeatureContext
+  extensions:
+    Behat\MinkExtension:
+      files_path: features/Resources
+      show_cmd: 'open %s'
+      goutte: ~
+      selenium2: ~
+
+      # Project base URL
+      #
+      # Use BEHAT_PARAMS="extensions[Behat\MinkExtension\Extension][base_url]=http://example.local/" for configuration during runtime.
+      #
+      base_url: http://neos5.behat.test/

--- a/Tests/Behavior/behat.yml.dist
+++ b/Tests/Behavior/behat.yml.dist
@@ -3,11 +3,16 @@
 # Override with behat.yml for local configuration.
 #
 default:
-  paths:
-    features: Features
-    bootstrap: %behat.paths.features%/Bootstrap
+  autoload:
+    '': "%paths.base%/Features/Bootstrap"
+  suites:
+    content:
+        paths:
+          - "%paths.base%/Features"
+        contexts:
+          - FeatureContext
   extensions:
-    Behat\MinkExtension\Extension:
+    Behat\MinkExtension:
       files_path: features/Resources
       show_cmd: 'open %s'
       goutte: ~

--- a/Tests/Functional/Service/NodeRedirectServiceTest.php
+++ b/Tests/Functional/Service/NodeRedirectServiceTest.php
@@ -128,6 +128,7 @@ class NodeRedirectServiceTest extends FunctionalTestCase
         $this->site = $sites->createNode('site', $this->nodeTypeManager->getNodeType('Neos.Neos:Document'), 'site');
         $site = new Site('site');
         $site->setSiteResourcesPackageKey('My.Package');
+        $site->setState(Site::STATE_ONLINE);
         $this->siteRepository->add($site);
     }
 

--- a/Tests/Functional/Service/NodeRedirectServiceTest.php
+++ b/Tests/Functional/Service/NodeRedirectServiceTest.php
@@ -19,13 +19,13 @@ use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\ContentRepository\Exception\NodeExistsException;
 use Neos\ContentRepository\Exception\NodeTypeNotFoundException;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
+use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Neos\Domain\Model\Site;
 use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Domain\Service\ContentContext;
 use Neos\Neos\Domain\Service\ContentContextFactory;
 use Neos\Neos\Service\PublishingService;
 use Neos\RedirectHandler\NeosAdapter\Service\NodeRedirectService;
-use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\RedirectHandler\Storage\RedirectStorageInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -145,13 +145,22 @@ class NodeRedirectServiceTest extends FunctionalTestCase
      * @throws NodeExistsException
      * @throws NodeTypeNotFoundException
      */
-    public function createRedirectsForPublishedNodeCreatesRedirectFromPreviousUriWhenMovingDocumentDown()
+    public function createRedirectsForPublishedNodeCreatesRedirectFromPreviousUriWhenMovingDocumentDown(): void
     {
         $documentNodeType = $this->nodeTypeManager->getNodeType('Neos.Neos:Document');
 
-        $this->mockRedirectStorage->expects($this->exactly(1))
+        $count = 0;
+        $this->mockRedirectStorage
             ->method('addRedirect')
-            ->with('/en/document.html', '/en/outer/document.html');
+            ->willReturnCallback(function ($sourceUri, $targetUri, $statusCode, $hosts) use (&$count) {
+                if ($sourceUri === '/en/document.html') {
+                    self::assertSame('/en/outer/document.html', $targetUri);
+                    self::assertSame(301, $statusCode);
+                    self::assertSame([], $hosts);
+                    $count++;
+                }
+                return [];
+            });
 
         $outerDocument = $this->site->createNode('outer', $documentNodeType);
         $outerDocument->setProperty('uriPathSegment', 'outer');
@@ -162,6 +171,9 @@ class NodeRedirectServiceTest extends FunctionalTestCase
         $documentToBeMoved->moveInto($outerDocument);
 
         $this->publishingService->publishNode($documentToBeMoved);
+        $this->persistenceManager->persistAll();
+
+        self::assertSame(1, $count, 'The primary redirect should have been created');
     }
 
     /**
@@ -169,13 +181,22 @@ class NodeRedirectServiceTest extends FunctionalTestCase
      * @throws NodeExistsException
      * @throws NodeTypeNotFoundException
      */
-    public function createRedirectsForPublishedNodeCreatesRedirectFromPreviousUriWhenMovingDocumentUp()
+    public function createRedirectsForPublishedNodeCreatesRedirectFromPreviousUriWhenMovingDocumentUp(): void
     {
         $documentNodeType = $this->nodeTypeManager->getNodeType('Neos.Neos:Document');
 
-        $this->mockRedirectStorage->expects($this->exactly(1))
+        $count = 0;
+        $this->mockRedirectStorage
             ->method('addRedirect')
-            ->with('/en/outer/document.html', '/en/document.html');
+            ->willReturnCallback(function ($sourceUri, $targetUri, $statusCode, $hosts) use (&$count) {
+                if ($sourceUri === '/en/outer/document.html') {
+                    self::assertSame('/en/document.html', $targetUri);
+                    self::assertSame(301, $statusCode);
+                    self::assertSame([], $hosts);
+                    $count++;
+                }
+                return [];
+            });
 
         $outerDocument = $this->site->createNode('outer', $documentNodeType);
         $outerDocument->setProperty('uriPathSegment', 'outer');
@@ -186,6 +207,9 @@ class NodeRedirectServiceTest extends FunctionalTestCase
         $documentToBeMoved->moveInto($this->site);
 
         $this->publishingService->publishNode($documentToBeMoved);
+        $this->persistenceManager->persistAll();
+
+        self::assertSame(1, $count, 'The primary redirect should have been created');
     }
 
     /**
@@ -193,21 +217,28 @@ class NodeRedirectServiceTest extends FunctionalTestCase
      * @throws NodeExistsException
      * @throws NodeTypeNotFoundException
      */
-    public function createRedirectsForPublishedNodeLeavesUpwardRedirectWhenMovingDocumentDownAndUp()
+    public function createRedirectsForPublishedNodeLeavesUpwardRedirectWhenMovingDocumentDownAndUp(): void
     {
         $documentNodeType = $this->nodeTypeManager->getNodeType('Neos.Neos:Document');
 
-        $this->mockRedirectStorage->expects($this->exactly(2))
+        $countA = 0;
+        $countB = 0;
+        $this->mockRedirectStorage
             ->method('addRedirect')
-            ->with($this->logicalOr(
-                $this->equalTo('/en/document.html'),
-                $this->equalTo('/en/outer/document.html')
-            ),
-                $this->logicalOr(
-                    $this->equalTo('/en/outer/document.html'),
-                    $this->equalTo('/en/document.html')
-                )
-            );
+            ->willReturnCallback(function ($sourceUri, $targetUri, $statusCode, $hosts) use (&$countA, &$countB) {
+                if ($sourceUri === '/en/outer/document.html') {
+                    self::assertSame('/en/document.html', $targetUri);
+                    self::assertSame(301, $statusCode);
+                    self::assertSame([], $hosts);
+                    $countA++;
+                } elseif ($sourceUri === '/en/document.html') {
+                    self::assertSame('/en/outer/document.html', $targetUri);
+                    self::assertSame(301, $statusCode);
+                    self::assertSame([], $hosts);
+                    $countB++;
+                }
+                return [];
+            });
 
         $outerDocument = $this->site->createNode('outer', $documentNodeType, 'outer');
         $outerDocument->setProperty('uriPathSegment', 'outer');
@@ -217,12 +248,15 @@ class NodeRedirectServiceTest extends FunctionalTestCase
         $documentToBeMoved = $this->userContext->adoptNode($document);
         $documentToBeMoved->moveInto($this->userContext->getNodeByIdentifier('outer'));
         $this->publishingService->publishNode($documentToBeMoved);
-        $this->nodeDataRepository->persistEntities();
+        $this->persistenceManager->persistAll();
 
         $documentToBeMoved = $this->userContext->adoptNode($outerDocument->getNode('document'));
         $documentToBeMoved->moveInto($this->userContext->getNodeByIdentifier('site'));
 
         $this->publishingService->publishNode($documentToBeMoved);
-        $this->nodeDataRepository->persistEntities();
+        $this->persistenceManager->persistAll();
+
+        self::assertSame(1, $countA, 'The primary redirect should have been created');
+        self::assertSame(1, $countB, 'The secondary redirect should have been created');
     }
 }


### PR DESCRIPTION
Without this change the redirect generation was not possible
f.e. when `flow workspace:publish` was used to publish a
workspace. The necessary http request to build uris was
not available.

Resolves: #41

## What I did

I check if the current request is from a CommandController a custom request ist built.
Flow baseUri setting or simply localhost is used as baseUri. But this uri does not really matter
as this change also now uses a nodes context for generating the direct.
This means the domain of the site a node is in will be used to define the host parameter
for a redirect. So multi-site installations will now receive the proper host for each redirect.
This should also improve the behaviour when publishing nodes from multiple sites at the same time via the backend.

If no domain is set, the redirect will have no host entry and is therefore relative and active for all sites.
Previously the requests domain was used for redirect generation.

## Tasks

- [x] Use Flow `baseUri` setting when possible for custom http request
- [x] Use redirect specific `baseUri` setting when possible for custom http request
- [x] Multi-site support
- [x] Documentation
- [ ] Maybe find better way to prevent setting `FLOW_REWRITEURLS` during generation
- [x] `ActionRequestFactory` is not available in Flow 5, find alternative