### PR TITLE
Relax version constraint to allow dev-master for neos and redirecthandler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "description": "Neos Redirect Handler",
     "license": "GPL-3.0-or-later",
     "require": {
-        "neos/redirecthandler": "~3.0 || ~4.0",
-        "neos/neos": "~4.3 || ~5.0"
+        "neos/redirecthandler": "~3.0 || ~4.0 || dev-master",
+        "neos/neos": "~4.3 || ~5.0 || dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Currently redirecthandler cannot be installed on master.