### PR TITLE
BUGFIX: Simplify and fix hasNodeUriChanged

### DIFF
--- a/Classes/Service/NodeRedirectService.php
+++ b/Classes/Service/NodeRedirectService.php
@@ -307,25 +307,20 @@ class NodeRedirectService
     protected function hasNodeUriChanged(NodeInterface $node, Workspace $targetWorkspace): bool
     {
         $nodeInTargetWorkspace = $this->getNodeInWorkspace($node, $targetWorkspace);
+
         if (!$nodeInTargetWorkspace) {
             return false;
         }
-        try {
-            $newUriPath = $this->buildUriPathForNode($node);
-        } catch (\Exception $exception) {
-            $this->logger->info(sprintf('Failed to build new URI for updated node "%s": %s', $node->getContextPath(), $exception->getMessage()));
-            return false;
-        }
-        $newUriPath = $this->removeContextInformationFromRelativeNodeUri($newUriPath);
-        try {
-            $oldUriPath = $this->buildUriPathForNode($nodeInTargetWorkspace);
-        } catch (\Exception $exception) {
-            $this->logger->info(sprintf('Failed to build previous URI for updated node "%s": %s', $node->getContextPath(), $exception->getMessage()));
-            return false;
-        }
-        $oldUriPath = $this->removeContextInformationFromRelativeNodeUri($oldUriPath);
 
-        return ($newUriPath !== $oldUriPath);
+        if ($node->getProperty('uriPathSegment') !== $nodeInTargetWorkspace->getProperty('uriPathSegment')) {
+            return true;
+        }
+
+        if ($node->getParentPath() !== $nodeInTargetWorkspace->getParentPath()) {
+            return true;
+        }
+
+        return false;
     }
 
     /**
@@ -568,7 +563,7 @@ class NodeRedirectService
     protected function buildUriPathForNode(NodeInterface $node): string
     {
         return $this->getUriBuilder()
-                ->uriFor('show', ['node' => $node], 'Frontend\\Node', 'Neos.Neos');
+            ->uriFor('show', ['node' => $node], 'Frontend\\Node', 'Neos.Neos');
     }
 
     /**

--- a/Classes/Service/NodeRedirectService.php
+++ b/Classes/Service/NodeRedirectService.php
@@ -169,7 +169,10 @@ class NodeRedirectService
         if ($targetWorkspace->isPublicWorkspace() === false || $nodeType->isOfType('Neos.Neos:Document') === false) {
             return;
         }
-        $this->appendNodeAndChildrenDocumentsToPendingRedirects($node, $targetWorkspace);
+
+        if ($this->hasNodeUriChanged($node, $targetWorkspace)) {
+            $this->appendNodeAndChildrenDocumentsToPendingRedirects($node, $targetWorkspace);
+        }
     }
 
     /**
@@ -252,10 +255,6 @@ class NodeRedirectService
     {
         $identifierAndWorkspaceKey = $node->getIdentifier() . '@' . $targetWorkspace->getName();
         if (isset($this->pendingRedirects[$identifierAndWorkspaceKey])) {
-            return;
-        }
-
-        if (!$this->hasNodeUriChanged($node, $targetWorkspace)) {
             return;
         }
 


### PR DESCRIPTION
Fixes: #61

There are two cases when the uri changes for the current node. Either the uriPathSegment has changed or it was moved, meaning the parentPath changed.

In our case, the publish time was reduced from 45 seconds to 3 seconds.