### PR TITLE
BUGFIX: Repair behat tests and Neos9-Beta-10 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,7 +122,8 @@ jobs:
     - name: Run Behavioral tests
       run: |
         cd ${NEOS_BASE_FOLDER}
-        bin/behat -f progress --strict --no-interaction -vvv --stop-on-failure -c Packages/Application/Neos.RedirectHandler.NeosAdapter/Tests/Behavior/behat.yml.dist
+        cd Packages/Application/Neos.RedirectHandler.NeosAdapter
+        composer run test:behavioral:stop-on-failure
 
     - name: Show log on failure
       if: ${{ failure()  }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,19 +109,13 @@ jobs:
                 dbname: 'neos_functional_testing'
         EOF
 
-    - name: Setup database schema
-      run: |
-        cd ${NEOS_BASE_FOLDER}
-        ./flow doctrine:migrate --quite
-
-    - name: Setup CR
-      run: |
-        cd ${NEOS_BASE_FOLDER}
-        ./flow cr:setup
-
     - name: Run Behavioral tests
       run: |
         cd ${NEOS_BASE_FOLDER}
+        # we have to doctrine migrate and setup the cr here as otherwise a transaction error will occur:
+        # see also https://github.com/neos/neos-development-collection/pull/5005
+        FLOW_CONTEXT=Testing ./flow doctrine:migrate --quiet; FLOW_CONTEXT=Testing ./flow cr:setup
+
         cd Packages/Application/Neos.RedirectHandler.NeosAdapter
         composer run test:behavioral:stop-on-failure
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
         cd ${NEOS_BASE_FOLDER}
         composer require --no-update --no-interaction neos/redirecthandler:"^6.0"
         composer require --no-update --no-interaction neos/redirecthandler-databasestorage:"^6.0"
-        
+
         git -C ../${{ env.PACKAGE_FOLDER }} checkout -b build
         composer config repositories.package '{ "type": "path", "url": "../${{ env.PACKAGE_FOLDER }}", "options": { "symlink": false } }'
         composer require --no-update --no-interaction neos/redirecthandler-neosadapter:"dev-build as dev-${PACKAGE_TARGET_VERSION}"
@@ -94,7 +94,7 @@ jobs:
 
     - name: Setup Flow configuration
       run: |
-        cd ${NEOS_BASE_FOLDER} 
+        cd ${NEOS_BASE_FOLDER}
         mkdir -p Configuration/Testing
         rm -f Configuration/Testing/Settings.yaml
         cat <<EOF >> Configuration/Testing/Settings.yaml
@@ -119,10 +119,10 @@ jobs:
         cd ${NEOS_BASE_FOLDER}
         ./flow cr:setup
 
-    - name: Run Functional tests
+    - name: Run Behavioral tests
       run: |
         cd ${NEOS_BASE_FOLDER}
-        CATCHUPTRIGGER_ENABLE_SYNCHRONOUS_OPTION=1 bin/behat -c Packages/Application/Neos.RedirectHandler.NeosAdapter/Tests/Behavior/behat.yml.dist
+        bin/behat -f progress --strict --no-interaction -vvv --stop-on-failure -c Packages/Application/Neos.RedirectHandler.NeosAdapter/Tests/Behavior/behat.yml.dist
 
     - name: Show log on failure
       if: ${{ failure()  }}

--- a/Tests/Behavior/Features/Bootstrap/FeatureContext.php
+++ b/Tests/Behavior/Features/Bootstrap/FeatureContext.php
@@ -1,58 +1,36 @@
 <?php
 
-use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Behat\Tests\Behat\FlowContextTrait;
-use Neos\Flow\Utility\Environment;
-use Neos\Neos\Tests\Functional\Command\BehatTestHelper;
-use Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\CRTestSuiteTrait;
 use Behat\Behat\Context\Context;
+use Neos\Behat\FlowBootstrapTrait;
+use Neos\Behat\FlowEntitiesTrait;
 use Neos\ContentRepository\BehavioralTests\TestSuite\Behavior\CRBehavioralTestsSubjectProvider;
-use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
+use Neos\ContentRepository\BehavioralTests\TestSuite\Behavior\GherkinPyStringNodeBasedNodeTypeManagerFactory;
+use Neos\ContentRepository\BehavioralTests\TestSuite\Behavior\GherkinTableNodeBasedContentDimensionSourceFactory;
+use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\Factory\ContentRepositoryId;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceFactoryInterface;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceInterface;
-use Neos\ContentRepository\Core\Factory\ContentRepositoryId;
-use Neos\ContentRepository\Core\ContentRepository;
-use Neos\ContentRepository\BehavioralTests\TestSuite\Behavior\GherkinTableNodeBasedContentDimensionSourceFactory;
-use Neos\ContentRepository\BehavioralTests\TestSuite\Behavior\GherkinPyStringNodeBasedNodeTypeManagerFactory;
+use Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\CRTestSuiteTrait;
+use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 
-require_once(__DIR__ . '/../../../../../../Application/Neos.Behat/Tests/Behat/FlowContextTrait.php');
 require_once(__DIR__ . '/../../../../../../Neos/Neos.Neos/Tests/Behavior/Features/Bootstrap/RoutingTrait.php');
 
-/**
- * Features context
- */
 class FeatureContext implements Context
 {
-    use FlowContextTrait;
+    use FlowBootstrapTrait;
+    use FlowEntitiesTrait;
     use CRTestSuiteTrait;
     use CRBehavioralTestsSubjectProvider;
 
     use RoutingTrait;
     use RedirectOperationTrait;
 
-    /**
-     * @var string
-     */
-    protected $behatTestHelperObjectName = BehatTestHelper::class;
-
-    /**
-     * @var ObjectManagerInterface
-     */
-    protected $objectManager;
-
-    /**
-     * @var Environment
-     */
-    protected $environment;
+    private ContentRepositoryRegistry $contentRepositoryRegistry;
 
     public function __construct()
     {
-        if (self::$bootstrap === null) {
-            self::$bootstrap = $this->initializeFlow();
-        }
-        $this->objectManager = self::$bootstrap->getObjectManager();
-        $this->contentRepositoryRegistry = $this->objectManager->get(ContentRepositoryRegistry::class);
-
+        self::bootstrapFlow();
+        $this->contentRepositoryRegistry = $this->getObject(ContentRepositoryRegistry::class);
         $this->setupCRTestSuiteTrait();
     }
 

--- a/Tests/Behavior/Features/Bootstrap/FeatureContext.php
+++ b/Tests/Behavior/Features/Bootstrap/FeatureContext.php
@@ -31,7 +31,6 @@ class FeatureContext implements Context
     {
         self::bootstrapFlow();
         $this->contentRepositoryRegistry = $this->getObject(ContentRepositoryRegistry::class);
-        $this->setupCRTestSuiteTrait();
     }
 
     protected function getContentRepositoryService(

--- a/Tests/Behavior/Features/Bootstrap/RedirectOperationTrait.php
+++ b/Tests/Behavior/Features/Bootstrap/RedirectOperationTrait.php
@@ -18,14 +18,22 @@ use PHPUnit\Framework\Assert;
 trait RedirectOperationTrait
 {
     /**
+     * @template T of object
+     * @param class-string<T> $className
+     *
+     * @return T
+     */
+    abstract private function getObject(string $className): object;
+
+    /**
      * @Given /^I have the following redirects:$/
      * @When /^I create the following redirects:$/
      */
     public function iHaveTheFollowingRedirects($table): void
     {
         $rows = $table->getHash();
-        $nodeRedirectStorage = $this->objectManager->get(RedirectStorage::class);
-        $redirectRepository = $this->objectManager->get(RedirectRepository::class);
+        $nodeRedirectStorage = $this->getObject(RedirectStorage::class);
+        $redirectRepository = $this->getObject(RedirectRepository::class);
 
         foreach ($rows as $row) {
             $nodeRedirectStorage->addRedirect(
@@ -42,7 +50,7 @@ trait RedirectOperationTrait
      */
     public function iShouldHaveARedirectWithSourceUriAndTargetUri($sourceUri, $targetUri): void
     {
-        $nodeRedirectStorage = $this->objectManager->get(RedirectStorage::class);
+        $nodeRedirectStorage = $this->getObject(RedirectStorage::class);
 
         $redirect = $nodeRedirectStorage->getOneBySourceUriPathAndHost($sourceUri);
 
@@ -62,7 +70,7 @@ trait RedirectOperationTrait
      */
     public function iShouldHaveARedirectWithSourceUriAndStatus($sourceUri, $statusCode): void
     {
-        $nodeRedirectStorage = $this->objectManager->get(RedirectStorage::class);
+        $nodeRedirectStorage = $this->getObject(RedirectStorage::class);
 
         $redirect = $nodeRedirectStorage->getOneBySourceUriPathAndHost($sourceUri);
 
@@ -82,7 +90,7 @@ trait RedirectOperationTrait
      */
     public function iShouldHaveNoRedirectWithSourceUriAndTargetUri($sourceUri, $targetUri): void
     {
-        $nodeRedirectStorage = $this->objectManager->get(RedirectStorage::class);
+        $nodeRedirectStorage = $this->getObject(RedirectStorage::class);
         $redirect = $nodeRedirectStorage->getOneBySourceUriPathAndHost($sourceUri);
 
         if ($redirect !== null) {
@@ -101,7 +109,7 @@ trait RedirectOperationTrait
      */
     public function iShouldHaveNoRedirectWithSourceUri($sourceUri): void
     {
-        $nodeRedirectStorage = $this->objectManager->get(RedirectStorage::class);
+        $nodeRedirectStorage = $this->getObject(RedirectStorage::class);
 
         $redirect = $nodeRedirectStorage->getOneBySourceUriPathAndHost($sourceUri);
 

--- a/Tests/Behavior/Features/MultipleDimensions.feature
+++ b/Tests/Behavior/Features/MultipleDimensions.feature
@@ -49,7 +49,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
       | nodeAggregateId | "site-root"       |
       | nodeTypeName    | "Neos.Neos:Sites" |
       | contentStreamId | "cs-identifier"   |
-    And the graph projection is fully up to date
 
     # site-root
     #   behat
@@ -99,7 +98,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
                         DE: DE
                         CH: CH
     """
-    And The documenturipath projection is up to date
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value                              |
       | nodeAggregateId | "behat"                            |
@@ -145,7 +143,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
       | dimensionSpacePoint                 | {"language": "en", "market": "DE"} |
       | newParentNodeAggregateId            | "company"                          |
       | newSucceedingSiblingNodeAggregateId | null                               |
-    And The documenturipath projection is up to date
     Then I should have a redirect with sourceUri "DE/imprint.html" and targetUri "DE/company/imprint.html"
     Then I should have a redirect with sourceUri "CH/imprint.html" and targetUri "CH/company/imprint.html"
     Then I should have a redirect with sourceUri "en_DE/imprint.html" and targetUri "en_DE/company/imprint.html"
@@ -162,7 +159,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
       | dimensionSpacePoint                 | {"language": "en", "market": "DE"} |
       | newParentNodeAggregateId            | "behat"                            |
       | newSucceedingSiblingNodeAggregateId | null                               |
-    And The documenturipath projection is up to date
 
     Then I should have a redirect with sourceUri "DE/company/service.html" and targetUri "DE/service.html"
     And I should have a redirect with sourceUri "CH/company/service.html" and targetUri "CH/service.html"
@@ -179,7 +175,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
       | nodeAggregateId           | "company"                          |
       | originDimensionSpacePoint | {"language": "en", "market": "CH"} |
       | propertyValues            | {"uriPathSegment": "evil-company"} |
-    And The documenturipath projection is up to date
 
     Then I should have a redirect with sourceUri "en_CH/company.html" and targetUri "en_CH/evil-company.html"
     And I should have a redirect with sourceUri "en_CH/company/service.html" and targetUri "en_CH/evil-company/service.html"
@@ -204,7 +199,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
       | nodeAggregateId           | "company"                            |
       | originDimensionSpacePoint | {"language": "en", "market": "CH"}   |
       | propertyValues            | {"uriPathSegment": "more-evil-corp"} |
-    And The documenturipath projection is up to date
 
     Then I should have a redirect with sourceUri "en_CH/company.html" and targetUri "en_CH/more-evil-corp.html"
     And I should have a redirect with sourceUri "en_CH/company/service.html" and targetUri "en_CH/more-evil-corp/service.html"
@@ -228,7 +222,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
       | nodeAggregateId           | "company"                          |
       | originDimensionSpacePoint | {"language": "en", "market": "CH"} |
       | propertyValues            | {"uriPathSegment": "my-company"}   |
-    And The documenturipath projection is up to date
     Then I should have a redirect with sourceUri "en_CH/company.html" and targetUri "en_CH/my-company.html"
     And I should have a redirect with sourceUri "en_CH/company/service.html" and targetUri "en_CH/my-company/service.html"
     And I should have a redirect with sourceUri "en_CH/company/about.html" and targetUri "en_CH/my-company/about.html"
@@ -243,7 +236,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
       | nodeAggregateId           | "buy"                              |
       | originDimensionSpacePoint | {"language": "en", "market": "DE"} |
       | propertyValues            | {"title": "my-buy"}                |
-    And The documenturipath projection is up to date
     Then I should have no redirect with sourceUri "en_DE/buy.html"
 
   @fixtures
@@ -254,7 +246,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
       | nodeAggregateId           | "restricted-by-nodetype"                         |
       | originDimensionSpacePoint | {"language": "en", "market": "DE"}               |
       | propertyValues            | {"uriPathSegment": "restricted-by-nodetype-new"} |
-    And The documenturipath projection is up to date
     Then I should have no redirect with sourceUri "en/restricted.html"
 
 #  @fixtures
@@ -265,14 +256,12 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
 #      | nodeAggregateId              | "mail"                             |
 #      | coveredDimensionSpacePoint   | {"language": "en", "market": "DE"} |
 #      | nodeVariantSelectionStrategy | "allVariants"                      |
-#    And the graph projection is fully up to date
 #    When the command SetNodeProperties is executed with payload:
 #      | Key                       | Value                              |
 #      | contentStreamId           | "cs-identifier"                    |
 #      | nodeAggregateId           | "mail"                             |
 #      | originDimensionSpacePoint | {"language": "en", "market": "DE"} |
 #      | propertyValues            | {"uriPathSegment": "not-mail"}     |
-#    And The documenturipath projection is up to date
 #    Then I should have a redirect with sourceUri "en_DE/mail.html" and targetUri "en_DE/not-mail.html"
 #    Then I should have a redirect with sourceUri "en_CH/mail.html" and targetUri "en_CH/not-mail.html"
 
@@ -284,7 +273,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
       | nodeAggregateId           | "company"                          |
       | originDimensionSpacePoint | {"language": "de", "market": "DE"} |
       | propertyValues            | {"uriPathSegment": "evil-company"} |
-    And The documenturipath projection is up to date
 
     Then I should have a redirect with sourceUri "DE/company.html" and targetUri "DE/evil-company.html"
     And I should have a redirect with sourceUri "DE/company/service.html" and targetUri "DE/evil-company/service.html"
@@ -308,8 +296,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
       | nodeAggregateId              | "company"                          |
       | coveredDimensionSpacePoint   | {"language": "en", "market": "CH"} |
       | nodeVariantSelectionStrategy | "allSpecializations"               |
-    And the graph projection is fully up to date
-    And The documenturipath projection is up to date
 
     Then I should have a redirect with sourceUri "en_CH/company.html" and statusCode "410"
     And I should have a redirect with sourceUri "en_CH/company.html" and targetUri ""
@@ -339,8 +325,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
       | nodeAggregateId              | "company"                          |
       | coveredDimensionSpacePoint   | {"language": "de", "market": "CH"} |
       | nodeVariantSelectionStrategy | "allVariants"                      |
-    And the graph projection is fully up to date
-    And The documenturipath projection is up to date
 
     Then I should have a redirect with sourceUri "DE/company.html" and statusCode "410"
     And I should have a redirect with sourceUri "DE/company.html" and targetUri ""
@@ -385,8 +369,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
       | nodeAggregateId              | "company"                           |
       | nodeVariantSelectionStrategy | "allSpecializations"                |
       | coveredDimensionSpacePoint   | {"language": "de", "market" : "DE"} |
-    And the graph projection is fully up to date
-    And The documenturipath projection is up to date
 
     Then I should have a redirect with sourceUri "DE/company.html" and statusCode "410"
     And I should have a redirect with sourceUri "DE/company.html" and targetUri ""

--- a/Tests/Behavior/Features/MultipleDimensions.feature
+++ b/Tests/Behavior/Features/MultipleDimensions.feature
@@ -1,4 +1,4 @@
-@fixtures @contentrepository
+@flowEntities
 Feature: Basic redirect handling with document nodes in multiple dimensions
 
   Background:

--- a/Tests/Behavior/Features/MultipleDimensions.feature
+++ b/Tests/Behavior/Features/MultipleDimensions.feature
@@ -133,7 +133,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
       | sourceOrigin    | {"language":"en", "market": "DE"} |
       | targetOrigin    | {"language":"en", "market": "CH"} |
 
-  @fixtures
   Scenario: Move a node down into different node and a redirect will be created
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                              |
@@ -148,7 +147,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
     Then I should have a redirect with sourceUri "ch_DE/imprint.html" and targetUri "ch_DE/company/imprint.html"
     Then I should have a redirect with sourceUri "ch_CH/imprint.html" and targetUri "ch_CH/company/imprint.html"
 
-  @fixtures
   Scenario: Move a node up into different node and a redirect will be created
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                              |
@@ -164,7 +162,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
     And I should have a redirect with sourceUri "ch_DE/company/service.html" and targetUri "ch_DE/service.html"
     And I should have a redirect with sourceUri "ch_CH/company/service.html" and targetUri "ch_CH/service.html"
 
-  @fixtures
   Scenario: Change the the `uriPathSegment` and a redirect will be created
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                              |
@@ -181,7 +178,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
     And I should have no redirect with sourceUri "ch_CH/company.html"
     And I should have no redirect with sourceUri "ch_DE/company.html"
 
-  @fixtures
   Scenario: Change the the `uriPathSegment` multiple times and multiple redirects will be created
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                              |
@@ -205,7 +201,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
     And I should have no redirect with sourceUri "DE/company.html"
     And I should have no redirect with sourceUri "en_DE/company.html"
 
-  @fixtures
   Scenario: Retarget an existing redirect when the source URI matches the source URI of the new redirect
     When I have the following redirects:
       | sourceuripath      | targeturipath          |
@@ -221,7 +216,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
 
     And I should have no redirect with sourceUri "en_CH/company.html" and targetUri "en_CH/company-old.html"
 
-  @fixtures
   Scenario: No redirect should be created for an existing node if any non URI related property changes
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                              |
@@ -230,7 +224,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
       | propertyValues            | {"title": "my-buy"}                |
     Then I should have no redirect with sourceUri "en_DE/buy.html"
 
-  @fixtures
   Scenario: No redirect should be created for an restricted node by nodetype
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                                            |
@@ -239,8 +232,7 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
       | propertyValues            | {"uriPathSegment": "restricted-by-nodetype-new"} |
     Then I should have no redirect with sourceUri "en/restricted.html"
 
-#  @fixtures
-#  Scenario: Redirects should be created for a hidden node
+##  Scenario: Redirects should be created for a hidden node
 #    When the command DisableNodeAggregate is executed with payload:
 #      | Key                          | Value                              |
 #      | nodeAggregateId              | "mail"                             |
@@ -254,7 +246,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
 #    Then I should have a redirect with sourceUri "en_DE/mail.html" and targetUri "en_DE/not-mail.html"
 #    Then I should have a redirect with sourceUri "en_CH/mail.html" and targetUri "en_CH/not-mail.html"
 
-  @fixtures
   Scenario: Change the the `uriPathSegment` and a redirect will be created also for fallback
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                              |
@@ -276,7 +267,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
     And I should have no redirect with sourceUri "en_CH/company.html"
     And I should have no redirect with sourceUri "en_CH/company/service.html"
 
-  @fixtures
   Scenario: A removed node should lead to a GONE response with empty target uri (allSpecializations)
     Given the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value                              |
@@ -304,7 +294,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
     And I should have no redirect with sourceUri "en_DE/company/service.html"
     And I should have no redirect with sourceUri "en_DE/company/about.html"
 
-  @fixtures
   Scenario: A removed node should lead to a GONE response with empty target uri (allVariants)
     Given the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value                              |
@@ -347,7 +336,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
     And I should have a redirect with sourceUri "en_DE/company/about.html" and targetUri ""
 
 
-  @fixtures
   Scenario: A removed node should lead to a GONE response with empty target uri also for fallback (allSpecializations)
     Given the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value                               |

--- a/Tests/Behavior/Features/MultipleDimensions.feature
+++ b/Tests/Behavior/Features/MultipleDimensions.feature
@@ -44,11 +44,11 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value             |
       | nodeAggregateId | "site-root"       |
       | nodeTypeName    | "Neos.Neos:Sites" |
-      | contentStreamId | "cs-identifier"   |
 
     # site-root
     #   behat
@@ -58,7 +58,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
     #      imprint
     #      buy
     #      mail
-    And I am in content stream "cs-identifier" and dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | parentNodeAggregateId | nodeTypeName                           | initialPropertyValues                        | originDimensionSpacePoint          | nodeName |
       | behat                  | site-root             | Neos.Neos:Test.Redirect.Page           | {"uriPathSegment": "home"}                   | {"language": "en", "market": "DE"} | node1    |
@@ -138,7 +137,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
   Scenario: Move a node down into different node and a redirect will be created
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                              |
-      | contentStreamId                     | "cs-identifier"                    |
       | nodeAggregateId                     | "imprint"                          |
       | dimensionSpacePoint                 | {"language": "en", "market": "DE"} |
       | newParentNodeAggregateId            | "company"                          |
@@ -154,7 +152,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
   Scenario: Move a node up into different node and a redirect will be created
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                              |
-      | contentStreamId                     | "cs-identifier"                    |
       | nodeAggregateId                     | "service"                          |
       | dimensionSpacePoint                 | {"language": "en", "market": "DE"} |
       | newParentNodeAggregateId            | "behat"                            |
@@ -171,7 +168,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
   Scenario: Change the the `uriPathSegment` and a redirect will be created
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                              |
-      | contentStreamId           | "cs-identifier"                    |
       | nodeAggregateId           | "company"                          |
       | originDimensionSpacePoint | {"language": "en", "market": "CH"} |
       | propertyValues            | {"uriPathSegment": "evil-company"} |
@@ -189,13 +185,11 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
   Scenario: Change the the `uriPathSegment` multiple times and multiple redirects will be created
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                              |
-      | contentStreamId           | "cs-identifier"                    |
       | nodeAggregateId           | "company"                          |
       | originDimensionSpacePoint | {"language": "en", "market": "CH"} |
       | propertyValues            | {"uriPathSegment": "evil-corp"}    |
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                                |
-      | contentStreamId           | "cs-identifier"                      |
       | nodeAggregateId           | "company"                            |
       | originDimensionSpacePoint | {"language": "en", "market": "CH"}   |
       | propertyValues            | {"uriPathSegment": "more-evil-corp"} |
@@ -218,7 +212,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
       | en_CH/company.html | en_CH/company-old.html |
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                              |
-      | contentStreamId           | "cs-identifier"                    |
       | nodeAggregateId           | "company"                          |
       | originDimensionSpacePoint | {"language": "en", "market": "CH"} |
       | propertyValues            | {"uriPathSegment": "my-company"}   |
@@ -232,7 +225,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
   Scenario: No redirect should be created for an existing node if any non URI related property changes
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                              |
-      | contentStreamId           | "cs-identifier"                    |
       | nodeAggregateId           | "buy"                              |
       | originDimensionSpacePoint | {"language": "en", "market": "DE"} |
       | propertyValues            | {"title": "my-buy"}                |
@@ -242,7 +234,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
   Scenario: No redirect should be created for an restricted node by nodetype
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                                            |
-      | contentStreamId           | "cs-identifier"                                  |
       | nodeAggregateId           | "restricted-by-nodetype"                         |
       | originDimensionSpacePoint | {"language": "en", "market": "DE"}               |
       | propertyValues            | {"uriPathSegment": "restricted-by-nodetype-new"} |
@@ -252,13 +243,11 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
 #  Scenario: Redirects should be created for a hidden node
 #    When the command DisableNodeAggregate is executed with payload:
 #      | Key                          | Value                              |
-#      | contentStreamId              | "cs-identifier"                    |
 #      | nodeAggregateId              | "mail"                             |
 #      | coveredDimensionSpacePoint   | {"language": "en", "market": "DE"} |
 #      | nodeVariantSelectionStrategy | "allVariants"                      |
 #    When the command SetNodeProperties is executed with payload:
 #      | Key                       | Value                              |
-#      | contentStreamId           | "cs-identifier"                    |
 #      | nodeAggregateId           | "mail"                             |
 #      | originDimensionSpacePoint | {"language": "en", "market": "DE"} |
 #      | propertyValues            | {"uriPathSegment": "not-mail"}     |
@@ -269,7 +258,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
   Scenario: Change the the `uriPathSegment` and a redirect will be created also for fallback
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                              |
-      | contentStreamId           | "cs-identifier"                    |
       | nodeAggregateId           | "company"                          |
       | originDimensionSpacePoint | {"language": "de", "market": "DE"} |
       | propertyValues            | {"uriPathSegment": "evil-company"} |
@@ -292,7 +280,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
   Scenario: A removed node should lead to a GONE response with empty target uri (allSpecializations)
     Given the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value                              |
-      | contentStreamId              | "cs-identifier"                    |
       | nodeAggregateId              | "company"                          |
       | coveredDimensionSpacePoint   | {"language": "en", "market": "CH"} |
       | nodeVariantSelectionStrategy | "allSpecializations"               |
@@ -321,7 +308,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
   Scenario: A removed node should lead to a GONE response with empty target uri (allVariants)
     Given the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value                              |
-      | contentStreamId              | "cs-identifier"                    |
       | nodeAggregateId              | "company"                          |
       | coveredDimensionSpacePoint   | {"language": "de", "market": "CH"} |
       | nodeVariantSelectionStrategy | "allVariants"                      |
@@ -365,7 +351,6 @@ Feature: Basic redirect handling with document nodes in multiple dimensions
   Scenario: A removed node should lead to a GONE response with empty target uri also for fallback (allSpecializations)
     Given the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value                               |
-      | contentStreamId              | "cs-identifier"                     |
       | nodeAggregateId              | "company"                           |
       | nodeVariantSelectionStrategy | "allSpecializations"                |
       | coveredDimensionSpacePoint   | {"language": "de", "market" : "DE"} |

--- a/Tests/Behavior/Features/OneDimension.feature
+++ b/Tests/Behavior/Features/OneDimension.feature
@@ -1,4 +1,4 @@
-@fixtures @contentrepository
+@flowEntities
 Feature: Basic redirect handling with document nodes in one dimension
 
   Background:

--- a/Tests/Behavior/Features/OneDimension.feature
+++ b/Tests/Behavior/Features/OneDimension.feature
@@ -112,7 +112,6 @@ Feature: Basic redirect handling with document nodes in one dimension
       | sourceOrigin    | {"language":"en"} |
       | targetOrigin    | {"language":"de"} |
 
-  @fixtures
   Scenario: Move a node down into different node and a redirect will be created
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value              |
@@ -124,7 +123,6 @@ Feature: Basic redirect handling with document nodes in one dimension
     And I should have a redirect with sourceUri "imprint.html" and targetUri "company/imprint.html"
     And I should have a redirect with sourceUri "ch/imprint.html" and targetUri "ch/company/imprint.html"
 
-  @fixtures
   Scenario: Move a node up into different node and a redirect will be created
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value              |
@@ -136,7 +134,6 @@ Feature: Basic redirect handling with document nodes in one dimension
     And I should have a redirect with sourceUri "company/service.html" and targetUri "service.html"
     And I should have a redirect with sourceUri "ch/company/service.html" and targetUri "ch/service.html"
 
-  @fixtures
   Scenario: Change the the `uriPathSegment` and a redirect will be created
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                           |
@@ -157,7 +154,6 @@ Feature: Basic redirect handling with document nodes in one dimension
     And I should have no redirect with sourceUri "ch/company/service.html"
 
 
-  @fixtures
   Scenario: Change the the `uriPathSegment` multiple times and multiple redirects will be created
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                           |
@@ -176,7 +172,6 @@ Feature: Basic redirect handling with document nodes in one dimension
     And I should have a redirect with sourceUri "en/evil-corp/service.html" and targetUri "en/more-evil-corp/service.html"
 
 
-  @fixtures
   Scenario: Retarget an existing redirect when the source URI matches the source URI of the new redirect
     When I have the following redirects:
       | sourceuripath | targeturipath |
@@ -190,7 +185,6 @@ Feature: Basic redirect handling with document nodes in one dimension
     And I should have no redirect with sourceUri "en/company.html" and targetUri "en/company-old.html"
     And I should have a redirect with sourceUri "en/company/service.html" and targetUri "en/my-company/service.html"
 
-  @fixtures
   Scenario: No redirect should be created for an existing node if any non URI related property changes
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value               |
@@ -199,7 +193,6 @@ Feature: Basic redirect handling with document nodes in one dimension
       | propertyValues            | {"title": "my-buy"} |
         Then I should have no redirect with sourceUri "en/buy.html"
 
-  @fixtures
   Scenario: No redirect should be created for an restricted node by nodetype
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                                            |
@@ -208,8 +201,7 @@ Feature: Basic redirect handling with document nodes in one dimension
       | propertyValues            | {"uriPathSegment": "restricted-by-nodetype-new"} |
         Then I should have no redirect with sourceUri "en/restricted.html"
 
-#  @fixtures
-#  Scenario: Redirects should be created for a hidden node
+##  Scenario: Redirects should be created for a hidden node
 #    When the command DisableNodeAggregate is executed with payload:
 #      | Key                          | Value              |
 #      | nodeAggregateId              | "mail"             |
@@ -222,7 +214,6 @@ Feature: Basic redirect handling with document nodes in one dimension
 #      | propertyValues            | {"uriPathSegment": "not-mail"} |
 #    #    Then I should have a redirect with sourceUri "en/mail.html" and targetUri "en/not-mail.html"
 
-  @fixtures
   Scenario: Change the the `uriPathSegment` and a redirect will be created also for fallback
 
     And the command SetNodeProperties is executed with payload:
@@ -237,7 +228,6 @@ Feature: Basic redirect handling with document nodes in one dimension
     And I should have a redirect with sourceUri "ch/company/service.html" and targetUri "ch/unternehmen/service.html"
 
 
-  @fixtures
   Scenario: A removed node should lead to a GONE response with empty target uri (allSpecializations)
     Given the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value                |
@@ -255,7 +245,6 @@ Feature: Basic redirect handling with document nodes in one dimension
     And I should have no redirect with sourceUri "ch/company.html"
     And I should have no redirect with sourceUri "ch/company/service.html"
 
-  @fixtures
   Scenario: A removed node should lead to a GONE response with empty target uri (allVariants)
     Given the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value              |
@@ -278,7 +267,6 @@ Feature: Basic redirect handling with document nodes in one dimension
     And I should have a redirect with sourceUri "ch/company/service.html" and statusCode "410"
     And I should have a redirect with sourceUri "ch/company/service.html" and targetUri ""
 
-  @fixtures
   Scenario: A removed node should lead to a GONE response with empty target uri also for fallback (allSpecializations)
     Given the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value                |

--- a/Tests/Behavior/Features/OneDimension.feature
+++ b/Tests/Behavior/Features/OneDimension.feature
@@ -43,11 +43,11 @@ Feature: Basic redirect handling with document nodes in one dimension
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value             |
       | nodeAggregateId | "site-root"       |
       | nodeTypeName    | "Neos.Neos:Sites" |
-      | contentStreamId | "cs-identifier"   |
 
     # site-root
     #   behat
@@ -57,7 +57,6 @@ Feature: Basic redirect handling with document nodes in one dimension
     #      imprint
     #      buy
     #      mail
-    And I am in content stream "cs-identifier" and dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | parentNodeAggregateId | nodeTypeName                           | initialPropertyValues                        | originDimensionSpacePoint | nodeName |
       | behat                  | site-root             | Neos.Neos:Test.Redirect.Page           | {"uriPathSegment": "home"}                   | {"language": "en"}        | node1    |
@@ -117,7 +116,6 @@ Feature: Basic redirect handling with document nodes in one dimension
   Scenario: Move a node down into different node and a redirect will be created
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value              |
-      | contentStreamId                     | "cs-identifier"    |
       | nodeAggregateId                     | "imprint"          |
       | dimensionSpacePoint                 | {"language": "en"} |
       | newParentNodeAggregateId            | "company"          |
@@ -130,7 +128,6 @@ Feature: Basic redirect handling with document nodes in one dimension
   Scenario: Move a node up into different node and a redirect will be created
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value              |
-      | contentStreamId                     | "cs-identifier"    |
       | nodeAggregateId                     | "service"          |
       | dimensionSpacePoint                 | {"language": "en"} |
       | newParentNodeAggregateId            | "behat"            |
@@ -143,7 +140,6 @@ Feature: Basic redirect handling with document nodes in one dimension
   Scenario: Change the the `uriPathSegment` and a redirect will be created
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                           |
-      | contentStreamId           | "cs-identifier"                 |
       | nodeAggregateId           | "company"                       |
       | originDimensionSpacePoint | {"language": "en"}              |
       | propertyValues            | {"uriPathSegment": "evil-corp"} |
@@ -165,13 +161,11 @@ Feature: Basic redirect handling with document nodes in one dimension
   Scenario: Change the the `uriPathSegment` multiple times and multiple redirects will be created
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                           |
-      | contentStreamId           | "cs-identifier"                 |
       | nodeAggregateId           | "company"                       |
       | originDimensionSpacePoint | {"language": "en"}              |
       | propertyValues            | {"uriPathSegment": "evil-corp"} |
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                                |
-      | contentStreamId           | "cs-identifier"                      |
       | nodeAggregateId           | "company"                            |
       | originDimensionSpacePoint | {"language": "en"}                   |
       | propertyValues            | {"uriPathSegment": "more-evil-corp"} |
@@ -189,7 +183,6 @@ Feature: Basic redirect handling with document nodes in one dimension
       | company       | company-old   |
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                            |
-      | contentStreamId           | "cs-identifier"                  |
       | nodeAggregateId           | "company"                        |
       | originDimensionSpacePoint | {"language": "en"}               |
       | propertyValues            | {"uriPathSegment": "my-company"} |
@@ -201,7 +194,6 @@ Feature: Basic redirect handling with document nodes in one dimension
   Scenario: No redirect should be created for an existing node if any non URI related property changes
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value               |
-      | contentStreamId           | "cs-identifier"     |
       | nodeAggregateId           | "buy"               |
       | originDimensionSpacePoint | {"language": "en"}  |
       | propertyValues            | {"title": "my-buy"} |
@@ -211,7 +203,6 @@ Feature: Basic redirect handling with document nodes in one dimension
   Scenario: No redirect should be created for an restricted node by nodetype
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                                            |
-      | contentStreamId           | "cs-identifier"                                  |
       | nodeAggregateId           | "restricted-by-nodetype"                         |
       | originDimensionSpacePoint | {"language": "en"}                               |
       | propertyValues            | {"uriPathSegment": "restricted-by-nodetype-new"} |
@@ -221,13 +212,11 @@ Feature: Basic redirect handling with document nodes in one dimension
 #  Scenario: Redirects should be created for a hidden node
 #    When the command DisableNodeAggregate is executed with payload:
 #      | Key                          | Value              |
-#      | contentStreamId              | "cs-identifier"    |
 #      | nodeAggregateId              | "mail"             |
 #      | coveredDimensionSpacePoint   | {"language": "en"} |
 #      | nodeVariantSelectionStrategy | "allVariants"      |
 ##    When the command SetNodeProperties is executed with payload:
 #      | Key                       | Value                          |
-#      | contentStreamId           | "cs-identifier"                |
 #      | nodeAggregateId           | "mail"                         |
 #      | originDimensionSpacePoint | {"language": "en"}             |
 #      | propertyValues            | {"uriPathSegment": "not-mail"} |
@@ -238,7 +227,6 @@ Feature: Basic redirect handling with document nodes in one dimension
 
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                             |
-      | contentStreamId           | "cs-identifier"                   |
       | nodeAggregateId           | "company"                         |
       | originDimensionSpacePoint | {"language": "de"}                |
       | propertyValues            | {"uriPathSegment": "unternehmen"} |
@@ -253,7 +241,6 @@ Feature: Basic redirect handling with document nodes in one dimension
   Scenario: A removed node should lead to a GONE response with empty target uri (allSpecializations)
     Given the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value                |
-      | contentStreamId              | "cs-identifier"      |
       | nodeAggregateId              | "company"            |
       | coveredDimensionSpacePoint   | {"language": "en"}   |
       | nodeVariantSelectionStrategy | "allSpecializations" |
@@ -272,7 +259,6 @@ Feature: Basic redirect handling with document nodes in one dimension
   Scenario: A removed node should lead to a GONE response with empty target uri (allVariants)
     Given the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value              |
-      | contentStreamId              | "cs-identifier"    |
       | nodeAggregateId              | "company"          |
       | coveredDimensionSpacePoint   | {"language": "de"} |
       | nodeVariantSelectionStrategy | "allVariants"      |
@@ -296,7 +282,6 @@ Feature: Basic redirect handling with document nodes in one dimension
   Scenario: A removed node should lead to a GONE response with empty target uri also for fallback (allSpecializations)
     Given the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value                |
-      | contentStreamId              | "cs-identifier"      |
       | nodeAggregateId              | "company"            |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | coveredDimensionSpacePoint   | {"language": "de"}   |

--- a/Tests/Behavior/Features/OneDimension.feature
+++ b/Tests/Behavior/Features/OneDimension.feature
@@ -48,7 +48,6 @@ Feature: Basic redirect handling with document nodes in one dimension
       | nodeAggregateId | "site-root"       |
       | nodeTypeName    | "Neos.Neos:Sites" |
       | contentStreamId | "cs-identifier"   |
-    And the graph projection is fully up to date
 
     # site-root
     #   behat
@@ -113,7 +112,6 @@ Feature: Basic redirect handling with document nodes in one dimension
       | nodeAggregateId | "imprint"         |
       | sourceOrigin    | {"language":"en"} |
       | targetOrigin    | {"language":"de"} |
-    And The documenturipath projection is up to date
 
   @fixtures
   Scenario: Move a node down into different node and a redirect will be created
@@ -124,8 +122,7 @@ Feature: Basic redirect handling with document nodes in one dimension
       | dimensionSpacePoint                 | {"language": "en"} |
       | newParentNodeAggregateId            | "company"          |
       | newSucceedingSiblingNodeAggregateId | null               |
-    And The documenturipath projection is up to date
-    Then I should have a redirect with sourceUri "en/imprint.html" and targetUri "en/company/imprint.html"
+        Then I should have a redirect with sourceUri "en/imprint.html" and targetUri "en/company/imprint.html"
     And I should have a redirect with sourceUri "imprint.html" and targetUri "company/imprint.html"
     And I should have a redirect with sourceUri "ch/imprint.html" and targetUri "ch/company/imprint.html"
 
@@ -138,8 +135,7 @@ Feature: Basic redirect handling with document nodes in one dimension
       | dimensionSpacePoint                 | {"language": "en"} |
       | newParentNodeAggregateId            | "behat"            |
       | newSucceedingSiblingNodeAggregateId | null               |
-    And The documenturipath projection is up to date
-    Then I should have a redirect with sourceUri "en/company/service.html" and targetUri "en/service.html"
+        Then I should have a redirect with sourceUri "en/company/service.html" and targetUri "en/service.html"
     And I should have a redirect with sourceUri "company/service.html" and targetUri "service.html"
     And I should have a redirect with sourceUri "ch/company/service.html" and targetUri "ch/service.html"
 
@@ -151,7 +147,6 @@ Feature: Basic redirect handling with document nodes in one dimension
       | nodeAggregateId           | "company"                       |
       | originDimensionSpacePoint | {"language": "en"}              |
       | propertyValues            | {"uriPathSegment": "evil-corp"} |
-    And The documenturipath projection is up to date
 
     Then I should have a redirect with sourceUri "en/company.html" and targetUri "en/evil-corp.html"
     And I should have a redirect with sourceUri "en/company/about.html" and targetUri "en/evil-corp/about.html"
@@ -180,7 +175,6 @@ Feature: Basic redirect handling with document nodes in one dimension
       | nodeAggregateId           | "company"                            |
       | originDimensionSpacePoint | {"language": "en"}                   |
       | propertyValues            | {"uriPathSegment": "more-evil-corp"} |
-    And The documenturipath projection is up to date
 
     Then I should have a redirect with sourceUri "en/company.html" and targetUri "en/more-evil-corp.html"
     And I should have a redirect with sourceUri "en/company/service.html" and targetUri "en/more-evil-corp/service.html"
@@ -199,8 +193,7 @@ Feature: Basic redirect handling with document nodes in one dimension
       | nodeAggregateId           | "company"                        |
       | originDimensionSpacePoint | {"language": "en"}               |
       | propertyValues            | {"uriPathSegment": "my-company"} |
-    And The documenturipath projection is up to date
-    Then I should have a redirect with sourceUri "en/company.html" and targetUri "en/my-company.html"
+        Then I should have a redirect with sourceUri "en/company.html" and targetUri "en/my-company.html"
     And I should have no redirect with sourceUri "en/company.html" and targetUri "en/company-old.html"
     And I should have a redirect with sourceUri "en/company/service.html" and targetUri "en/my-company/service.html"
 
@@ -212,8 +205,7 @@ Feature: Basic redirect handling with document nodes in one dimension
       | nodeAggregateId           | "buy"               |
       | originDimensionSpacePoint | {"language": "en"}  |
       | propertyValues            | {"title": "my-buy"} |
-    And The documenturipath projection is up to date
-    Then I should have no redirect with sourceUri "en/buy.html"
+        Then I should have no redirect with sourceUri "en/buy.html"
 
   @fixtures
   Scenario: No redirect should be created for an restricted node by nodetype
@@ -223,8 +215,7 @@ Feature: Basic redirect handling with document nodes in one dimension
       | nodeAggregateId           | "restricted-by-nodetype"                         |
       | originDimensionSpacePoint | {"language": "en"}                               |
       | propertyValues            | {"uriPathSegment": "restricted-by-nodetype-new"} |
-    And The documenturipath projection is up to date
-    Then I should have no redirect with sourceUri "en/restricted.html"
+        Then I should have no redirect with sourceUri "en/restricted.html"
 
 #  @fixtures
 #  Scenario: Redirects should be created for a hidden node
@@ -234,15 +225,13 @@ Feature: Basic redirect handling with document nodes in one dimension
 #      | nodeAggregateId              | "mail"             |
 #      | coveredDimensionSpacePoint   | {"language": "en"} |
 #      | nodeVariantSelectionStrategy | "allVariants"      |
-#    And the graph projection is fully up to date
-#    When the command SetNodeProperties is executed with payload:
+##    When the command SetNodeProperties is executed with payload:
 #      | Key                       | Value                          |
 #      | contentStreamId           | "cs-identifier"                |
 #      | nodeAggregateId           | "mail"                         |
 #      | originDimensionSpacePoint | {"language": "en"}             |
 #      | propertyValues            | {"uriPathSegment": "not-mail"} |
-#    And The documenturipath projection is up to date
-#    Then I should have a redirect with sourceUri "en/mail.html" and targetUri "en/not-mail.html"
+#    #    Then I should have a redirect with sourceUri "en/mail.html" and targetUri "en/not-mail.html"
 
   @fixtures
   Scenario: Change the the `uriPathSegment` and a redirect will be created also for fallback
@@ -253,7 +242,6 @@ Feature: Basic redirect handling with document nodes in one dimension
       | nodeAggregateId           | "company"                         |
       | originDimensionSpacePoint | {"language": "de"}                |
       | propertyValues            | {"uriPathSegment": "unternehmen"} |
-    And The documenturipath projection is up to date
 
     Then I should have a redirect with sourceUri "company.html" and targetUri "unternehmen.html"
     And I should have a redirect with sourceUri "company/service.html" and targetUri "unternehmen/service.html"
@@ -269,8 +257,6 @@ Feature: Basic redirect handling with document nodes in one dimension
       | nodeAggregateId              | "company"            |
       | coveredDimensionSpacePoint   | {"language": "en"}   |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-    And the graph projection is fully up to date
-    And The documenturipath projection is up to date
 
     Then I should have a redirect with sourceUri "en/company.html" and statusCode "410"
     And I should have a redirect with sourceUri "en/company.html" and targetUri ""
@@ -290,8 +276,6 @@ Feature: Basic redirect handling with document nodes in one dimension
       | nodeAggregateId              | "company"          |
       | coveredDimensionSpacePoint   | {"language": "de"} |
       | nodeVariantSelectionStrategy | "allVariants"      |
-    And the graph projection is fully up to date
-    And The documenturipath projection is up to date
 
     Then I should have a redirect with sourceUri "en/company.html" and statusCode "410"
     And I should have a redirect with sourceUri "en/company.html" and targetUri ""
@@ -316,8 +300,6 @@ Feature: Basic redirect handling with document nodes in one dimension
       | nodeAggregateId              | "company"            |
       | nodeVariantSelectionStrategy | "allSpecializations" |
       | coveredDimensionSpacePoint   | {"language": "de"}   |
-    And the graph projection is fully up to date
-    And The documenturipath projection is up to date
 
     Then I should have a redirect with sourceUri "company.html" and statusCode "410"
     And I should have a redirect with sourceUri "company.html" and targetUri ""

--- a/Tests/Behavior/Features/WithoutDimensions.feature
+++ b/Tests/Behavior/Features/WithoutDimensions.feature
@@ -1,4 +1,4 @@
-@fixtures @contentrepository
+@flowEntities
 Feature: Basic redirect handling with document nodes without dimensions
 
   Background:

--- a/Tests/Behavior/Features/WithoutDimensions.feature
+++ b/Tests/Behavior/Features/WithoutDimensions.feature
@@ -48,7 +48,6 @@ Feature: Basic redirect handling with document nodes without dimensions
       | contentStreamId | "cs-identifier"   |
       | nodeAggregateId | "site-root"       |
       | nodeTypeName    | "Neos.Neos:Sites" |
-    And the graph projection is fully up to date
 
     # site-root
     #   behat
@@ -82,7 +81,6 @@ Feature: Basic redirect handling with document nodes without dimensions
               resolver:
                 factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\NoopResolverFactory
     """
-    And The documenturipath projection is up to date
 
   @fixtures
   Scenario: Move a node down into different node and a redirect will be created
@@ -93,8 +91,7 @@ Feature: Basic redirect handling with document nodes without dimensions
       | dimensionSpacePoint                 | {}              |
       | newParentNodeAggregateId            | "company"       |
       | newSucceedingSiblingNodeAggregateId | null            |
-    And The documenturipath projection is up to date
-    Then I should have a redirect with sourceUri "imprint.html" and targetUri "company/imprint.html"
+        Then I should have a redirect with sourceUri "imprint.html" and targetUri "company/imprint.html"
 
   Scenario: Move a node up into different node and a redirect will be created
     When the command MoveNodeAggregate is executed with payload:
@@ -104,8 +101,7 @@ Feature: Basic redirect handling with document nodes without dimensions
       | dimensionSpacePoint                 | {}              |
       | newParentNodeAggregateId            | "behat"         |
       | newSucceedingSiblingNodeAggregateId | null            |
-    And The documenturipath projection is up to date
-    Then I should have a redirect with sourceUri "company/service.html" and targetUri "service.html"
+        Then I should have a redirect with sourceUri "company/service.html" and targetUri "service.html"
 
   @fixtures
   Scenario: Change the the `uriPathSegment` and a redirect will be created
@@ -115,8 +111,7 @@ Feature: Basic redirect handling with document nodes without dimensions
       | nodeAggregateId           | "company"                       |
       | originDimensionSpacePoint | {}                              |
       | propertyValues            | {"uriPathSegment": "evil-corp"} |
-    And The documenturipath projection is up to date
-    Then I should have a redirect with sourceUri "company.html" and targetUri "evil-corp.html"
+        Then I should have a redirect with sourceUri "company.html" and targetUri "evil-corp.html"
     And I should have a redirect with sourceUri "company/service.html" and targetUri "evil-corp/service.html"
 
   @fixtures
@@ -133,7 +128,6 @@ Feature: Basic redirect handling with document nodes without dimensions
       | nodeAggregateId           | "company"                            |
       | originDimensionSpacePoint | {}                                   |
       | propertyValues            | {"uriPathSegment": "more-evil-corp"} |
-    And The documenturipath projection is up to date
 
     Then I should have a redirect with sourceUri "company.html" and targetUri "more-evil-corp.html"
     And I should have a redirect with sourceUri "company/service.html" and targetUri "more-evil-corp/service.html"
@@ -152,8 +146,7 @@ Feature: Basic redirect handling with document nodes without dimensions
       | nodeAggregateId           | "company"                        |
       | originDimensionSpacePoint | {}                               |
       | propertyValues            | {"uriPathSegment": "my-company"} |
-    And The documenturipath projection is up to date
-    Then I should have a redirect with sourceUri "company.html" and targetUri "my-company.html"
+        Then I should have a redirect with sourceUri "company.html" and targetUri "my-company.html"
     And I should have no redirect with sourceUri "company.html" and targetUri "company-old.html"
     And I should have a redirect with sourceUri "company/service.html" and targetUri "my-company/service.html"
 
@@ -165,8 +158,7 @@ Feature: Basic redirect handling with document nodes without dimensions
       | nodeAggregateId           | "buy"               |
       | originDimensionSpacePoint | {}                  |
       | propertyValues            | {"title": "my-buy"} |
-    And The documenturipath projection is up to date
-    Then I should have no redirect with sourceUri "buy.html"
+        Then I should have no redirect with sourceUri "buy.html"
 
   @fixtures
   Scenario: No redirect should be created for an restricted node by nodetype
@@ -176,8 +168,7 @@ Feature: Basic redirect handling with document nodes without dimensions
       | nodeAggregateId           | "restricted-by-nodetype"                         |
       | originDimensionSpacePoint | {}                                               |
       | propertyValues            | {"uriPathSegment": "restricted-by-nodetype-new"} |
-    And The documenturipath projection is up to date
-    Then I should have no redirect with sourceUri "restricted.html"
+        Then I should have no redirect with sourceUri "restricted.html"
 
   @fixtures
   Scenario: Redirects should be created for a hidden node
@@ -187,15 +178,13 @@ Feature: Basic redirect handling with document nodes without dimensions
       | nodeAggregateId              | "mail"          |
       | coveredDimensionSpacePoint   | {}              |
       | nodeVariantSelectionStrategy | "allVariants"   |
-    And the graph projection is fully up to date
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                          |
       | contentStreamId           | "cs-identifier"                |
       | nodeAggregateId           | "mail"                         |
       | originDimensionSpacePoint | {}                             |
       | propertyValues            | {"uriPathSegment": "not-mail"} |
-    And The documenturipath projection is up to date
-    Then I should have a redirect with sourceUri "mail.html" and targetUri "not-mail.html"
+        Then I should have a redirect with sourceUri "mail.html" and targetUri "not-mail.html"
 
   @fixtures
   Scenario: A removed node should lead to a GONE response with empty target uri
@@ -204,8 +193,6 @@ Feature: Basic redirect handling with document nodes without dimensions
       | contentStreamId              | "cs-identifier" |
       | nodeAggregateId              | "company"       |
       | nodeVariantSelectionStrategy | "allVariants"   |
-    And the graph projection is fully up to date
-    And The documenturipath projection is up to date
 
     Then I should have a redirect with sourceUri "company.html" and statusCode "410"
     And I should have a redirect with sourceUri "company.html" and targetUri ""

--- a/Tests/Behavior/Features/WithoutDimensions.feature
+++ b/Tests/Behavior/Features/WithoutDimensions.feature
@@ -43,9 +43,9 @@ Feature: Basic redirect handling with document nodes without dimensions
       | workspaceTitle       | "Live"               |
       | workspaceDescription | "The live workspace" |
       | newContentStreamId   | "cs-identifier"      |
+    And I am in workspace "live" and dimension space point {}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value             |
-      | contentStreamId | "cs-identifier"   |
       | nodeAggregateId | "site-root"       |
       | nodeTypeName    | "Neos.Neos:Sites" |
 
@@ -57,7 +57,6 @@ Feature: Basic redirect handling with document nodes without dimensions
     #      imprint
     #      buy
     #      mail
-    And I am in content stream "cs-identifier" and dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | parentNodeAggregateId | nodeTypeName                           | initialPropertyValues                        | nodeName |
       | behat                  | site-root             | Neos.Neos:Test.Redirect.Page           | {"uriPathSegment": "home"}                   | node1    |
@@ -86,7 +85,6 @@ Feature: Basic redirect handling with document nodes without dimensions
   Scenario: Move a node down into different node and a redirect will be created
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value           |
-      | contentStreamId                     | "cs-identifier" |
       | nodeAggregateId                     | "imprint"       |
       | dimensionSpacePoint                 | {}              |
       | newParentNodeAggregateId            | "company"       |
@@ -96,7 +94,6 @@ Feature: Basic redirect handling with document nodes without dimensions
   Scenario: Move a node up into different node and a redirect will be created
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value           |
-      | contentStreamId                     | "cs-identifier" |
       | nodeAggregateId                     | "service"       |
       | dimensionSpacePoint                 | {}              |
       | newParentNodeAggregateId            | "behat"         |
@@ -107,7 +104,6 @@ Feature: Basic redirect handling with document nodes without dimensions
   Scenario: Change the the `uriPathSegment` and a redirect will be created
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                           |
-      | contentStreamId           | "cs-identifier"                 |
       | nodeAggregateId           | "company"                       |
       | originDimensionSpacePoint | {}                              |
       | propertyValues            | {"uriPathSegment": "evil-corp"} |
@@ -118,13 +114,11 @@ Feature: Basic redirect handling with document nodes without dimensions
   Scenario: Change the the `uriPathSegment` multiple times and multiple redirects will be created
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                           |
-      | contentStreamId           | "cs-identifier"                 |
       | nodeAggregateId           | "company"                       |
       | originDimensionSpacePoint | {}                              |
       | propertyValues            | {"uriPathSegment": "evil-corp"} |
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                                |
-      | contentStreamId           | "cs-identifier"                      |
       | nodeAggregateId           | "company"                            |
       | originDimensionSpacePoint | {}                                   |
       | propertyValues            | {"uriPathSegment": "more-evil-corp"} |
@@ -142,7 +136,6 @@ Feature: Basic redirect handling with document nodes without dimensions
       | company       | company-old   |
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                            |
-      | contentStreamId           | "cs-identifier"                  |
       | nodeAggregateId           | "company"                        |
       | originDimensionSpacePoint | {}                               |
       | propertyValues            | {"uriPathSegment": "my-company"} |
@@ -154,7 +147,6 @@ Feature: Basic redirect handling with document nodes without dimensions
   Scenario: No redirect should be created for an existing node if any non URI related property changes
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value               |
-      | contentStreamId           | "cs-identifier"     |
       | nodeAggregateId           | "buy"               |
       | originDimensionSpacePoint | {}                  |
       | propertyValues            | {"title": "my-buy"} |
@@ -164,7 +156,6 @@ Feature: Basic redirect handling with document nodes without dimensions
   Scenario: No redirect should be created for an restricted node by nodetype
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                                            |
-      | contentStreamId           | "cs-identifier"                                  |
       | nodeAggregateId           | "restricted-by-nodetype"                         |
       | originDimensionSpacePoint | {}                                               |
       | propertyValues            | {"uriPathSegment": "restricted-by-nodetype-new"} |
@@ -174,13 +165,11 @@ Feature: Basic redirect handling with document nodes without dimensions
   Scenario: Redirects should be created for a hidden node
     When the command DisableNodeAggregate is executed with payload:
       | Key                          | Value           |
-      | contentStreamId              | "cs-identifier" |
       | nodeAggregateId              | "mail"          |
       | coveredDimensionSpacePoint   | {}              |
       | nodeVariantSelectionStrategy | "allVariants"   |
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                          |
-      | contentStreamId           | "cs-identifier"                |
       | nodeAggregateId           | "mail"                         |
       | originDimensionSpacePoint | {}                             |
       | propertyValues            | {"uriPathSegment": "not-mail"} |
@@ -190,7 +179,6 @@ Feature: Basic redirect handling with document nodes without dimensions
   Scenario: A removed node should lead to a GONE response with empty target uri
     Given the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value           |
-      | contentStreamId              | "cs-identifier" |
       | nodeAggregateId              | "company"       |
       | nodeVariantSelectionStrategy | "allVariants"   |
 

--- a/Tests/Behavior/Features/WithoutDimensions.feature
+++ b/Tests/Behavior/Features/WithoutDimensions.feature
@@ -81,7 +81,6 @@ Feature: Basic redirect handling with document nodes without dimensions
                 factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\NoopResolverFactory
     """
 
-  @fixtures
   Scenario: Move a node down into different node and a redirect will be created
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value           |
@@ -100,17 +99,15 @@ Feature: Basic redirect handling with document nodes without dimensions
       | newSucceedingSiblingNodeAggregateId | null            |
         Then I should have a redirect with sourceUri "company/service.html" and targetUri "service.html"
 
-  @fixtures
   Scenario: Change the the `uriPathSegment` and a redirect will be created
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                           |
       | nodeAggregateId           | "company"                       |
       | originDimensionSpacePoint | {}                              |
       | propertyValues            | {"uriPathSegment": "evil-corp"} |
-        Then I should have a redirect with sourceUri "company.html" and targetUri "evil-corp.html"
+    Then I should have a redirect with sourceUri "company.html" and targetUri "evil-corp.html"
     And I should have a redirect with sourceUri "company/service.html" and targetUri "evil-corp/service.html"
 
-  @fixtures
   Scenario: Change the the `uriPathSegment` multiple times and multiple redirects will be created
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                           |
@@ -129,7 +126,6 @@ Feature: Basic redirect handling with document nodes without dimensions
     And I should have a redirect with sourceUri "evil-corp/service.html" and targetUri "more-evil-corp/service.html"
 
 
-  @fixtures
   Scenario: Retarget an existing redirect when the source URI matches the source URI of the new redirect
     When I have the following redirects:
       | sourceuripath | targeturipath |
@@ -143,7 +139,6 @@ Feature: Basic redirect handling with document nodes without dimensions
     And I should have no redirect with sourceUri "company.html" and targetUri "company-old.html"
     And I should have a redirect with sourceUri "company/service.html" and targetUri "my-company/service.html"
 
-  @fixtures
   Scenario: No redirect should be created for an existing node if any non URI related property changes
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value               |
@@ -152,7 +147,6 @@ Feature: Basic redirect handling with document nodes without dimensions
       | propertyValues            | {"title": "my-buy"} |
         Then I should have no redirect with sourceUri "buy.html"
 
-  @fixtures
   Scenario: No redirect should be created for an restricted node by nodetype
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                                            |
@@ -161,7 +155,6 @@ Feature: Basic redirect handling with document nodes without dimensions
       | propertyValues            | {"uriPathSegment": "restricted-by-nodetype-new"} |
         Then I should have no redirect with sourceUri "restricted.html"
 
-  @fixtures
   Scenario: Redirects should be created for a hidden node
     When the command DisableNodeAggregate is executed with payload:
       | Key                          | Value           |
@@ -175,7 +168,6 @@ Feature: Basic redirect handling with document nodes without dimensions
       | propertyValues            | {"uriPathSegment": "not-mail"} |
         Then I should have a redirect with sourceUri "mail.html" and targetUri "not-mail.html"
 
-  @fixtures
   Scenario: A removed node should lead to a GONE response with empty target uri
     Given the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value           |

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,10 @@
         "neos/neos": "^9.0",
         "neos/flow": "^9.0"
     },
+    "scripts": {
+        "test:behat-cli": "../../../bin/behat -f progress --strict --no-interaction",
+        "test:behavioral:stop-on-failure": "@test:behat-cli -c Tests/Behavior/behat.yml.dist -vvv --stop-on-failure"
+    },
     "autoload": {
         "psr-4": {
             "Neos\\RedirectHandler\\NeosAdapter\\": "Classes"


### PR DESCRIPTION
The way how we write behat tests has undergone major changes via `neos/behat` and the runtime helpers in Neos as well.
For example we use workspace names now and dont block anymore.

Resolves: #76