### PR TITLE
BUGFIX: Fix constructor injection in `NodeRedirectService`

### DIFF
--- a/Classes/Service/NodeRedirectService.php
+++ b/Classes/Service/NodeRedirectService.php
@@ -76,13 +76,9 @@ final class NodeRedirectService
     protected array $restrictByNodeType = [];
 
     public function __construct(
-        #[Flow\Inject]
         protected RedirectStorageInterface $redirectStorage,
-        #[Flow\Inject]
         protected PersistenceManagerInterface $persistenceManager,
-        #[Flow\Inject]
         protected ContentRepositoryRegistry $contentRepositoryRegistry,
-        #[Flow\Inject]
         protected SiteRepository $siteRepository,
     ) {
     }


### PR DESCRIPTION
Using `#[Flow\inject]` on a constructor parameter fails with `Attribute "Neos\Flow\Annotations\Inject" cannot target parameter (allowed targets: property)`.
