### PR TITLE
only react on NodeAggregateWasMoved when there is a new parent

### DIFF
--- a/Classes/CatchUpHook/DocumentUriPathProjectionHook.php
+++ b/Classes/CatchUpHook/DocumentUriPathProjectionHook.php
@@ -195,6 +195,10 @@ final class DocumentUriPathProjectionHook implements CatchUpHookInterface
             return;
         }
 
+        if (!$event->newParentNodeAggregateId) {
+            return;
+        }
+
         foreach ($event->succeedingSiblingsForCoverage as $interdimensionalSibling) {
             $node = $this->findNodeByIdAndDimensionSpacePointHash($event->nodeAggregateId, $interdimensionalSibling->dimensionSpacePoint->hash);
             if ($node === null) {


### PR DESCRIPTION
when moving among siblings, the URI does not change, so no redirect has to be handled